### PR TITLE
Refactored `Parser`

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ public class Example {
     public static void main(String[] args) {
         try (
             Parser parser = new Parser(Language.PYTHON);
-            Tree tree = parser.parseString("def foo(bar, baz):\n  print(bar)\n  print(baz)")
+            Tree tree = parser.parse("def foo(bar, baz):\n  print(bar)\n  print(baz)")
         ) {
             Node root = tree.getRootNode();
             assert root.getChildCount() == 1;
@@ -131,7 +131,7 @@ public class Example {
     public static void main(String[] args) {
         try (
             Parser parser = new Parser(Language.PYTHON);
-            Tree tree = parser.parseString("print(\"hi\")")
+            Tree tree = parser.parse("print(\"hi\")")
         ) {
             String actual = tree.getRootNode().getNodeString();
             String expected = "(module (expression_statement (call function: (identifier) arguments: (argument_list (string)))))";
@@ -156,7 +156,7 @@ public class Example {
         String type;
         try (
             Parser parser = new Parser(Language.PYTHON);
-            Tree tree = parser.parseString("def foo(bar, baz):\n  print(bar)\n  print(baz)");
+            Tree tree = parser.parse("def foo(bar, baz):\n  print(bar)\n  print(baz)");
             TreeCursor cursor = tree.getRootNode().walk()
         ) {
             type = cursor.getCurrentTreeCursorNode().getType();
@@ -189,7 +189,7 @@ public class Example {
     public static void main(String[] args) {
         try (
             Parser parser = new Parser(Language.PYTHON);
-            Tree tree = parser.parseString("print(\"hi\")");
+            Tree tree = parser.parse("print(\"hi\")");
             TreeCursor cursor = tree.getRootNode().walk()
         ) {
             SyntaxTreePrinter printer = new SyntaxTreePrinter(cursor);

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ To use in your own Maven project, include the following in your POM file:
 <dependency>
   <groupId>ch.usi.si.seart</groupId>
   <artifactId>java-tree-sitter</artifactId>
-  <version>1.2.1</version>
+  <version>1.3.0</version>
 </dependency>
 ```
 

--- a/lib/ch_usi_si_seart_treesitter_Parser.h
+++ b/lib/ch_usi_si_seart_treesitter_Parser.h
@@ -49,18 +49,10 @@ JNIEXPORT void JNICALL Java_ch_usi_si_seart_treesitter_Parser_setTimeout
 
 /*
  * Class:     ch_usi_si_seart_treesitter_Parser
- * Method:    parseBytes
- * Signature: ([BI)J
+ * Method:    parse
+ * Signature: ([BILch/usi/si/seart/treesitter/Tree;)Lch/usi/si/seart/treesitter/Tree;
  */
-JNIEXPORT jlong JNICALL Java_ch_usi_si_seart_treesitter_Parser_parseBytes___3BI
-  (JNIEnv *, jobject, jbyteArray, jint);
-
-/*
- * Class:     ch_usi_si_seart_treesitter_Parser
- * Method:    parseBytes
- * Signature: ([BILch/usi/si/seart/treesitter/Tree;)J
- */
-JNIEXPORT jlong JNICALL Java_ch_usi_si_seart_treesitter_Parser_parseBytes___3BILch_usi_si_seart_treesitter_Tree_2
+JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Parser_parse
   (JNIEnv *, jobject, jbyteArray, jint, jobject);
 
 #ifdef __cplusplus

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>ch.usi.si.seart</groupId>
   <artifactId>java-tree-sitter</artifactId>
-  <version>1.2.2-SNAPSHOT</version>
+  <version>1.3.0-SNAPSHOT</version>
 
   <name>${project.groupId}:${project.artifactId}</name>
   <description>Java bindings for tree-sitter</description>

--- a/src/main/java/ch/usi/si/seart/treesitter/Parser.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Parser.java
@@ -159,11 +159,8 @@ public class Parser extends External {
      */
     public Tree parseString(@NotNull String source) throws UnsupportedEncodingException {
         byte[] bytes = source.getBytes(CHARSET);
-        long treePointer = parseBytes(bytes, bytes.length);
-        return new Tree(treePointer, language);
+        return parse(bytes, bytes.length, null);
     }
-
-    private native long parseBytes(byte[] source, int length);
 
     /**
      * Use the parser to incrementally parse a changed source code string,
@@ -179,11 +176,10 @@ public class Parser extends External {
      */
     public Tree parseString(@NotNull String source, @NotNull Tree oldTree) throws UnsupportedEncodingException {
         byte[] bytes = source.getBytes(CHARSET);
-        long treePointer = parseBytes(bytes, bytes.length, oldTree);
-        return new Tree(treePointer, language);
+        return parse(bytes, bytes.length, oldTree);
     }
 
-    private native long parseBytes(byte[] source, int length, Tree oldTree);
+    private native Tree parse(byte[] bytes, int length, Tree oldTree);
 
     /**
      * Use the parser to parse some source code found in a file at the specified path.

--- a/src/main/java/ch/usi/si/seart/treesitter/Parser.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Parser.java
@@ -9,6 +9,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -31,6 +32,8 @@ import java.util.concurrent.TimeUnit;
 public class Parser extends External {
 
     Language language;
+
+    private static final Charset CHARSET = StandardCharsets.UTF_16LE;
 
     /**
      * @param language The language used for parsing
@@ -155,7 +158,7 @@ public class Parser extends External {
      * If the UTF-16LE character set is not supported
      */
     public Tree parseString(@NotNull String source) throws UnsupportedEncodingException {
-        byte[] bytes = source.getBytes(StandardCharsets.UTF_16LE);
+        byte[] bytes = source.getBytes(CHARSET);
         long treePointer = parseBytes(bytes, bytes.length);
         return new Tree(treePointer, language);
     }
@@ -175,7 +178,7 @@ public class Parser extends External {
      * If the UTF-16LE character set is not supported
      */
     public Tree parseString(@NotNull String source, @NotNull Tree oldTree) throws UnsupportedEncodingException {
-        byte[] bytes = source.getBytes(StandardCharsets.UTF_16LE);
+        byte[] bytes = source.getBytes(CHARSET);
         long treePointer = parseBytes(bytes, bytes.length, oldTree);
         return new Tree(treePointer, language);
     }

--- a/src/main/java/ch/usi/si/seart/treesitter/Parser.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Parser.java
@@ -163,7 +163,7 @@ public class Parser extends External {
         return new Tree(treePointer, language);
     }
 
-    native long parseBytes(byte[] source, int length);
+    private native long parseBytes(byte[] source, int length);
 
     /**
      * Use the parser to incrementally parse a changed source code string,
@@ -183,7 +183,7 @@ public class Parser extends External {
         return new Tree(treePointer, language);
     }
 
-    native long parseBytes(byte[] source, int length, Tree oldTree);
+    private native long parseBytes(byte[] source, int length, Tree oldTree);
 
     /**
      * Use the parser to parse some source code found in a file at the specified path.

--- a/src/main/java/ch/usi/si/seart/treesitter/Parser.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Parser.java
@@ -1,6 +1,7 @@
 package ch.usi.si.seart.treesitter;
 
 import ch.usi.si.seart.treesitter.error.ABIVersionError;
+import ch.usi.si.seart.treesitter.exception.ParsingException;
 import lombok.AccessLevel;
 import lombok.Generated;
 import lombok.Getter;
@@ -148,18 +149,32 @@ public class Parser extends External {
     public native void setTimeout(long timeout);
 
     /**
+     * @deprecated Use {@link #parse(String)} instead
+     */
+    @Deprecated(since = "1.3.0", forRemoval = true)
+    public Tree parseString(@NotNull String source) throws UnsupportedEncodingException {
+        return parse(source);
+    }
+
+    /**
      * Use the parser to parse some source code and create a syntax tree.
      *
      * @param source The source code string to be parsed
      * @return A syntax tree matching the provided source
-     * @throws ch.usi.si.seart.treesitter.exception.ParsingException
-     * If a parsing failure occurs (e.g. timeout)
-     * @throws UnsupportedEncodingException
-     * If the UTF-16LE character set is not supported
+     * @throws ParsingException if a parsing failure occurs
+     * @since 1.3.0
      */
-    public Tree parseString(@NotNull String source) throws UnsupportedEncodingException {
+    public Tree parse(@NotNull String source) throws ParsingException {
         byte[] bytes = source.getBytes(CHARSET);
         return parse(bytes, bytes.length, null);
+    }
+
+    /**
+     * @deprecated Use {@link #parse(String, Tree)} instead
+     */
+    @Deprecated(since = "1.3.0", forRemoval = true)
+    public Tree parseString(@NotNull String source, @NotNull Tree oldTree) throws UnsupportedEncodingException {
+        return parse(source, oldTree);
     }
 
     /**
@@ -169,32 +184,60 @@ public class Parser extends External {
      * @param source The source code string to be parsed
      * @param oldTree The syntax tree before changes were made
      * @return A syntax tree matching the provided source
-     * @throws ch.usi.si.seart.treesitter.exception.ParsingException
-     * If a parsing failure occurs (e.g. timeout)
-     * @throws UnsupportedEncodingException
-     * If the UTF-16LE character set is not supported
+     * @throws ParsingException if a parsing failure occurs
+     * @since 1.3.0
      */
-    public Tree parseString(@NotNull String source, @NotNull Tree oldTree) throws UnsupportedEncodingException {
+    public Tree parse(@NotNull String source, @NotNull Tree oldTree) throws ParsingException {
         byte[] bytes = source.getBytes(CHARSET);
         return parse(bytes, bytes.length, oldTree);
     }
 
-    private native Tree parse(byte[] bytes, int length, Tree oldTree);
+    /**
+     * @deprecated Use {@link #parse(Path)} instead
+     */
+    @Deprecated(since = "1.3.0", forRemoval = true)
+    public Tree parseFile(@NotNull Path path) throws IOException {
+        String source = Files.readString(path);
+        return parseString(source);
+    }
 
     /**
      * Use the parser to parse some source code found in a file at the specified path.
      *
      * @param path The path of the file to be parsed
      * @return A tree-sitter Tree matching the provided source
-     * @throws IOException If an I/O error occurs reading from
-     * the file or a malformed or unmappable byte sequence is read
-     * @throws OutOfMemoryError If the file is extremely large,
-     * for example larger than 2GB
+     * @throws ParsingException if a parsing failure occurs
+     * @since 1.3.0
      */
-    public Tree parseFile(@NotNull Path path) throws IOException {
-        String source = Files.readString(path);
-        return parseString(source);
+    public Tree parse(@NotNull Path path) throws ParsingException {
+        try {
+            String source = Files.readString(path);
+            return parse(source);
+        } catch (IOException ex) {
+            throw new ParsingException(ex);
+        }
     }
+
+    /**
+     * Use the parser to parse some source code found in a file at the specified path,
+     * reusing unchanged parts of the tree to speed up the process.
+     *
+     * @param path The path of the file to be parsed
+     * @param oldTree The syntax tree before changes were made
+     * @return A tree-sitter Tree matching the provided source
+     * @throws ParsingException if a parsing failure occurs
+     * @since 1.3.0
+     */
+    public Tree parse(@NotNull Path path, @NotNull Tree oldTree) throws ParsingException {
+        try {
+            String source = Files.readString(path);
+            return parse(source, oldTree);
+        } catch (IOException ex) {
+            throw new ParsingException(ex);
+        }
+    }
+
+    private native Tree parse(byte[] bytes, int length, Tree oldTree);
 
     @Override
     @Generated

--- a/src/test/java/ch/usi/si/seart/treesitter/NodeTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/NodeTest.java
@@ -23,7 +23,7 @@ class NodeTest extends TestBase {
     @SneakyThrows(UnsupportedEncodingException.class)
     static void beforeAll() {
         parser = new Parser(Language.PYTHON);
-        tree = parser.parseString(source);
+        tree = parser.parse(source);
         root = tree.getRootNode();
     }
 
@@ -173,7 +173,7 @@ class NodeTest extends TestBase {
     @Test
     @SneakyThrows(UnsupportedEncodingException.class)
     void testHasError() {
-        @Cleanup Tree tree = parser.parseString("def foo(bar, baz):\n  print(bar.)");
+        @Cleanup Tree tree = parser.parse("def foo(bar, baz):\n  print(bar.)");
         Node root = tree.getRootNode();
         Node function = root.getChild(0);
         Node def = function.getChild(0);
@@ -185,7 +185,7 @@ class NodeTest extends TestBase {
     @Test
     @SneakyThrows(UnsupportedEncodingException.class)
     void testIsExtra() {
-        @Cleanup Tree tree = parser.parseString("# this is just a comment");
+        @Cleanup Tree tree = parser.parse("# this is just a comment");
         Node root = tree.getRootNode();
         Node comment = root.getChild(0);
         Assertions.assertFalse(root.isExtra());
@@ -196,7 +196,7 @@ class NodeTest extends TestBase {
     @SneakyThrows(UnsupportedEncodingException.class)
     void testIsMissing() {
         @Cleanup Parser parser = new Parser(Language.JAVA);
-        @Cleanup Tree tree = parser.parseString("class C { public static final int i = 6 }");
+        @Cleanup Tree tree = parser.parse("class C { public static final int i = 6 }");
         Node root = tree.getRootNode();
         Assertions.assertFalse(root.isMissing());
         Assertions.assertFalse(root.getChild(0).isMissing());

--- a/src/test/java/ch/usi/si/seart/treesitter/NodeTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/NodeTest.java
@@ -1,13 +1,11 @@
 package ch.usi.si.seart.treesitter;
 
 import lombok.Cleanup;
-import lombok.SneakyThrows;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import java.io.UnsupportedEncodingException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -20,7 +18,6 @@ class NodeTest extends TestBase {
     private static Node root;
 
     @BeforeAll
-    @SneakyThrows(UnsupportedEncodingException.class)
     static void beforeAll() {
         parser = new Parser(Language.PYTHON);
         tree = parser.parse(source);
@@ -171,7 +168,6 @@ class NodeTest extends TestBase {
     }
 
     @Test
-    @SneakyThrows(UnsupportedEncodingException.class)
     void testHasError() {
         @Cleanup Tree tree = parser.parse("def foo(bar, baz):\n  print(bar.)");
         Node root = tree.getRootNode();
@@ -183,7 +179,6 @@ class NodeTest extends TestBase {
     }
 
     @Test
-    @SneakyThrows(UnsupportedEncodingException.class)
     void testIsExtra() {
         @Cleanup Tree tree = parser.parse("# this is just a comment");
         Node root = tree.getRootNode();
@@ -193,7 +188,6 @@ class NodeTest extends TestBase {
     }
 
     @Test
-    @SneakyThrows(UnsupportedEncodingException.class)
     void testIsMissing() {
         @Cleanup Parser parser = new Parser(Language.JAVA);
         @Cleanup Tree tree = parser.parse("class C { public static final int i = 6 }");

--- a/src/test/java/ch/usi/si/seart/treesitter/ParserTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/ParserTest.java
@@ -44,14 +44,14 @@ class ParserTest extends TestBase {
     @Test
     @SneakyThrows(UnsupportedEncodingException.class)
     void testParseString() {
-        @Cleanup Tree tree = parser.parseString(source);
+        @Cleanup Tree tree = parser.parse(source);
         Assertions.assertEquals(nodeString, tree.getRootNode().getNodeString());
     }
 
     @Test
     @SneakyThrows(IOException.class)
     void testParseFile() {
-        @Cleanup Tree tree = parser.parseFile(tmpFile);
+        @Cleanup Tree tree = parser.parse(tmpFile);
         Assertions.assertEquals(nodeString, tree.getRootNode().getNodeString());
     }
 
@@ -61,7 +61,7 @@ class ParserTest extends TestBase {
         @Cleanup Parser parser = new Parser(Language.PYTHON);
         parser.setLanguage(Language.JAVA);
         String source = "public class _ {}";
-        @Cleanup Tree tree = parser.parseString(source);
+        @Cleanup Tree tree = parser.parse(source);
         Assertions.assertEquals(
                 "(program (class_declaration (modifiers) name: (identifier) body: (class_body)))",
                 tree.getRootNode().getNodeString()
@@ -77,15 +77,15 @@ class ParserTest extends TestBase {
         parser.setTimeout(10);
         Assertions.assertEquals(10, parser.getTimeout());
         Path path = Path.of(getClass().getClassLoader().getResource("deep_string_concat").toURI());
-        Assertions.assertThrows(ParsingException.class, () -> parser.parseFile(path));
+        Assertions.assertThrows(ParsingException.class, () -> parser.parse(path));
         TimeUnit unit = TimeUnit.SECONDS;
         parser.setTimeout(1, unit);
         Assertions.assertEquals(unit.toMicros(1), parser.getTimeout());
-        Assertions.assertFalse(parser.parseFile(path).isNull());
+        Assertions.assertFalse(parser.parse(path).isNull());
         Duration duration = Duration.ofSeconds(1);
         parser.setTimeout(duration);
         Assertions.assertEquals(duration.toMillis() * 1000, parser.getTimeout());
-        Assertions.assertFalse(parser.parseFile(path).isNull());
+        Assertions.assertFalse(parser.parse(path).isNull());
         parser.setTimeout(Duration.ofNanos(500));
         Assertions.assertEquals(0, parser.getTimeout());
         parser.setTimeout(500, TimeUnit.NANOSECONDS);

--- a/src/test/java/ch/usi/si/seart/treesitter/ParserTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/ParserTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -42,21 +41,18 @@ class ParserTest extends TestBase {
     }
 
     @Test
-    @SneakyThrows(UnsupportedEncodingException.class)
     void testParseString() {
         @Cleanup Tree tree = parser.parse(source);
         Assertions.assertEquals(nodeString, tree.getRootNode().getNodeString());
     }
 
     @Test
-    @SneakyThrows(IOException.class)
     void testParseFile() {
         @Cleanup Tree tree = parser.parse(tmpFile);
         Assertions.assertEquals(nodeString, tree.getRootNode().getNodeString());
     }
 
     @Test
-    @SneakyThrows(IOException.class)
     void testParserSetLanguage() {
         @Cleanup Parser parser = new Parser(Language.PYTHON);
         parser.setLanguage(Language.JAVA);
@@ -70,7 +66,7 @@ class ParserTest extends TestBase {
 
     @Test
     @SuppressWarnings("DataFlowIssue")
-    @SneakyThrows({URISyntaxException.class, IOException.class})
+    @SneakyThrows(URISyntaxException.class)
     void testParserTimeout() {
         @Cleanup Parser parser = new Parser(Language.JAVA);
         Assertions.assertEquals(0, parser.getTimeout());

--- a/src/test/java/ch/usi/si/seart/treesitter/QueryCursorTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/QueryCursorTest.java
@@ -1,13 +1,11 @@
 package ch.usi.si.seart.treesitter;
 
 import lombok.Cleanup;
-import lombok.SneakyThrows;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import java.io.UnsupportedEncodingException;
 import java.util.Iterator;
 import java.util.Spliterator;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -23,7 +21,6 @@ class QueryCursorTest extends TestBase {
     private static Node root;
 
     @BeforeAll
-    @SneakyThrows(UnsupportedEncodingException.class)
     static void beforeAll() {
         parser = new Parser(language);
         tree = parser.parse(source);

--- a/src/test/java/ch/usi/si/seart/treesitter/QueryCursorTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/QueryCursorTest.java
@@ -26,7 +26,7 @@ class QueryCursorTest extends TestBase {
     @SneakyThrows(UnsupportedEncodingException.class)
     static void beforeAll() {
         parser = new Parser(language);
-        tree = parser.parseString(source);
+        tree = parser.parse(source);
         root = tree.getRootNode();
     }
 

--- a/src/test/java/ch/usi/si/seart/treesitter/TreeCursorTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/TreeCursorTest.java
@@ -22,7 +22,7 @@ class TreeCursorTest extends TestBase {
     @SneakyThrows(UnsupportedEncodingException.class)
     static void beforeAll() {
         parser = new Parser(Language.PYTHON);
-        tree = parser.parseString("def foo(bar, baz):\n  print(bar)\n  print(baz)");
+        tree = parser.parse("def foo(bar, baz):\n  print(bar)\n  print(baz)");
     }
 
     @BeforeEach

--- a/src/test/java/ch/usi/si/seart/treesitter/TreeCursorTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/TreeCursorTest.java
@@ -1,6 +1,5 @@
 package ch.usi.si.seart.treesitter;
 
-import lombok.SneakyThrows;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -8,7 +7,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.io.UnsupportedEncodingException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 class TreeCursorTest extends TestBase {
@@ -19,7 +17,6 @@ class TreeCursorTest extends TestBase {
     private TreeCursor cursor;
 
     @BeforeAll
-    @SneakyThrows(UnsupportedEncodingException.class)
     static void beforeAll() {
         parser = new Parser(Language.PYTHON);
         tree = parser.parse("def foo(bar, baz):\n  print(bar)\n  print(baz)");

--- a/src/test/java/ch/usi/si/seart/treesitter/TreeTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/TreeTest.java
@@ -1,16 +1,12 @@
 package ch.usi.si.seart.treesitter;
 
 import lombok.Cleanup;
-import lombok.SneakyThrows;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-
-import java.io.UnsupportedEncodingException;
 
 class TreeTest extends TestBase {
 
     @Test
-    @SneakyThrows(UnsupportedEncodingException.class)
     void testTreeEdit() {
         @Cleanup Parser parser = new Parser(Language.JAVA);
 

--- a/src/test/java/ch/usi/si/seart/treesitter/TreeTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/TreeTest.java
@@ -14,7 +14,7 @@ class TreeTest extends TestBase {
     void testTreeEdit() {
         @Cleanup Parser parser = new Parser(Language.JAVA);
 
-        Tree tree = parser.parseString("class Main {\n    // This is a line comment\n}");
+        Tree tree = parser.parse("class Main {\n    // This is a line comment\n}");
 
         Node root = tree.getRootNode();
         Node body = root.getChild(0).getChildByFieldName("body");
@@ -33,7 +33,7 @@ class TreeTest extends TestBase {
 
         tree.edit(inputEdit);
 
-        tree = parser.parseString("class Main {\n}", tree);
+        tree = parser.parse("class Main {\n}", tree);
 
         String newSExp = tree.getRootNode().getNodeString();
         Assertions.assertNotEquals(oldSExp, newSExp);

--- a/src/test/java/ch/usi/si/seart/treesitter/printer/DotGraphPrinterTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/printer/DotGraphPrinterTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -28,7 +27,6 @@ class DotGraphPrinterTest extends TestBase {
             "}";
 
     @Test
-    @SneakyThrows(UnsupportedEncodingException.class)
     void testPrint() {
         @Cleanup Parser parser = new Parser(Language.JAVA);
         @Cleanup Tree tree = parser.parse(source);
@@ -38,7 +36,7 @@ class DotGraphPrinterTest extends TestBase {
     }
 
     @Test
-    @SneakyThrows({UnsupportedEncodingException.class, IOException.class})
+    @SneakyThrows(IOException.class)
     void testExport() {
         @Cleanup Parser parser = new Parser(Language.JAVA);
         @Cleanup Tree tree = parser.parse(source);

--- a/src/test/java/ch/usi/si/seart/treesitter/printer/DotGraphPrinterTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/printer/DotGraphPrinterTest.java
@@ -31,7 +31,7 @@ class DotGraphPrinterTest extends TestBase {
     @SneakyThrows(UnsupportedEncodingException.class)
     void testPrint() {
         @Cleanup Parser parser = new Parser(Language.JAVA);
-        @Cleanup Tree tree = parser.parseString(source);
+        @Cleanup Tree tree = parser.parse(source);
         TreePrinter printer = new DotGraphPrinter(tree);
         String actual = printer.print();
         assertion(actual);
@@ -41,7 +41,7 @@ class DotGraphPrinterTest extends TestBase {
     @SneakyThrows({UnsupportedEncodingException.class, IOException.class})
     void testExport() {
         @Cleanup Parser parser = new Parser(Language.JAVA);
-        @Cleanup Tree tree = parser.parseString(source);
+        @Cleanup Tree tree = parser.parse(source);
         TreePrinter printer = new DotGraphPrinter(tree);
         File file = printer.export();
         Path path = file.toPath();

--- a/src/test/java/ch/usi/si/seart/treesitter/printer/PrinterTestBase.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/printer/PrinterTestBase.java
@@ -23,7 +23,7 @@ public abstract class PrinterTestBase extends TestBase {
     protected void testPrint() {
         String source = getSource();
         @Cleanup Parser parser = getParser();
-        @Cleanup Tree tree = parser.parseString(source);
+        @Cleanup Tree tree = parser.parse(source);
         @Cleanup TreeCursor cursor = getCursor(tree);
         TreePrinter printer = getPrinter(cursor);
         String expected = getExpected();
@@ -36,7 +36,7 @@ public abstract class PrinterTestBase extends TestBase {
     protected void testExport() {
         String source = getSource();
         @Cleanup Parser parser = getParser();
-        @Cleanup Tree tree = parser.parseString(source);
+        @Cleanup Tree tree = parser.parse(source);
         @Cleanup TreeCursor cursor = getCursor(tree);
         TreePrinter printer = getPrinter(cursor);
         String expected = getExpected();

--- a/src/test/java/ch/usi/si/seart/treesitter/printer/PrinterTestBase.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/printer/PrinterTestBase.java
@@ -12,14 +12,12 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
 public abstract class PrinterTestBase extends TestBase {
 
     @Test
-    @SneakyThrows(UnsupportedEncodingException.class)
     protected void testPrint() {
         String source = getSource();
         @Cleanup Parser parser = getParser();
@@ -32,7 +30,7 @@ public abstract class PrinterTestBase extends TestBase {
     }
 
     @Test
-    @SneakyThrows({UnsupportedEncodingException.class, IOException.class})
+    @SneakyThrows(IOException.class)
     protected void testExport() {
         String source = getSource();
         @Cleanup Parser parser = getParser();


### PR DESCRIPTION
Simplified the native code while all methods are moved under a single umbrella: `parse`.
Old `parseString` and `parseFile` variants are now deprecated and will be removed in a future release.