### PR TITLE
Introducing new printer: `SymbolicExpressionPrinter`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Highlights include:
 - A wide range of languages [supported](.gitmodules) out of the box
 - Streamlined native library construction, packaging and runtime loading
 - Safer interop with native code to minimize risks of segmentation faults
-- Multiple AST export formats: DOT, XML and human-readable syntax trees
+- Multiple AST export formats: DOT, XML, [symbolic expression](https://en.wikipedia.org/wiki/S-expression) and human-readable syntax trees
 - Various other quality-of-life improvements
 
 ## Local development
@@ -59,7 +59,7 @@ To use in your own Maven project, include the following in your POM file:
 <dependency>
   <groupId>ch.usi.si.seart</groupId>
   <artifactId>java-tree-sitter</artifactId>
-  <version>1.3.0</version>
+  <version>1.4.0</version>
 </dependency>
 ```
 
@@ -112,30 +112,6 @@ public class Example {
             Node function = root.getChild(0);
             assert function.getType().equals("function_definition");
             assert function.getChildCount() == 5;
-        } catch (Exception ex) {
-            // ...
-        }
-    }
-}
-```
-
-For debugging, it can be helpful to see a [symbolic expression](https://en.wikipedia.org/wiki/S-expression) representation of the tree structure:
-
-```java
-import ch.usi.si.seart.treesitter.*;
-
-public class Example {
-
-    // init omitted...
-
-    public static void main(String[] args) {
-        try (
-            Parser parser = new Parser(Language.PYTHON);
-            Tree tree = parser.parse("print(\"hi\")")
-        ) {
-            String actual = tree.getRootNode().getNodeString();
-            String expected = "(module (expression_statement (call function: (identifier) arguments: (argument_list (string)))))";
-            assert expected.equals(actual);
         } catch (Exception ex) {
             // ...
         }

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>ch.usi.si.seart</groupId>
   <artifactId>java-tree-sitter</artifactId>
-  <version>1.3.1-SNAPSHOT</version>
+  <version>1.4.0-SNAPSHOT</version>
 
   <name>${project.groupId}:${project.artifactId}</name>
   <description>Java bindings for tree-sitter</description>

--- a/src/main/java/ch/usi/si/seart/treesitter/Node.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Node.java
@@ -118,7 +118,10 @@ public class Node implements Iterable<Node> {
 
     /**
      * @return An S-expression representing the node as a string
+     * @deprecated <strong>This operation is potentially unsafe for large trees</strong>
+     * @see ch.usi.si.seart.treesitter.printer.SymbolicExpressionPrinter SymbolicExpressionPrinter
      */
+    @Deprecated(since = "1.4.0", forRemoval = true)
     public native String getNodeString();
 
     /**

--- a/src/main/java/ch/usi/si/seart/treesitter/printer/IterativeTreePrinter.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/printer/IterativeTreePrinter.java
@@ -1,11 +1,21 @@
 package ch.usi.si.seart.treesitter.printer;
 
 import ch.usi.si.seart.treesitter.TreeCursor;
+import ch.usi.si.seart.treesitter.function.IOExceptionThrowingConsumer;
 import lombok.AccessLevel;
+import lombok.Cleanup;
 import lombok.experimental.FieldDefaults;
 import org.jetbrains.annotations.NotNull;
 
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.io.Writer;
+import java.nio.file.Files;
 import java.util.Objects;
+import java.util.function.Consumer;
 
 @FieldDefaults(level = AccessLevel.PROTECTED, makeFinal = true)
 abstract class IterativeTreePrinter implements TreePrinter {
@@ -15,4 +25,47 @@ abstract class IterativeTreePrinter implements TreePrinter {
     protected IterativeTreePrinter(@NotNull TreeCursor cursor) {
         this.cursor = Objects.requireNonNull(cursor, "Cursor must not be null!");
     }
+
+    /**
+     * Generates a string representation of the Abstract Syntax Tree (AST),
+     * starting from the node currently pointed to by the cursor.
+     *
+     * @return A string representation of the tree
+     */
+    public final String print() {
+        StringBuilder stringBuilder = new StringBuilder(getPreamble());
+        write(stringBuilder::append);
+        return stringBuilder.toString();
+    }
+
+    /**
+     * Generates a string representation of the Abstract Syntax Tree (AST),
+     * starting from the node currently pointed to by the cursor,
+     * while writing outputs directly to a file.
+     *
+     * @return A file containing the string of the tree
+     * @throws IOException if an I/O error occurs
+     */
+    public final File export() throws IOException {
+        File file = Files.createTempFile("ts-export-", getFileExtension()).toFile();
+        @Cleanup Writer writer = new BufferedWriter(new FileWriter(file));
+        writer.append(getPreamble());
+        Consumer<String> appender = IOExceptionThrowingConsumer.toUnchecked(writer::append);
+        try {
+            write(appender);
+        } catch (UncheckedIOException ex) {
+            throw ex.getCause();
+        }
+        return file;
+    }
+
+    protected String getPreamble() {
+        return "";
+    }
+
+    protected String getFileExtension() {
+        return "";
+    }
+
+    protected abstract void write(Consumer<String> appender);
 }

--- a/src/main/java/ch/usi/si/seart/treesitter/printer/SymbolicExpressionPrinter.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/printer/SymbolicExpressionPrinter.java
@@ -1,0 +1,66 @@
+package ch.usi.si.seart.treesitter.printer;
+
+import ch.usi.si.seart.treesitter.TreeCursor;
+import ch.usi.si.seart.treesitter.TreeCursorNode;
+import lombok.AccessLevel;
+import lombok.experimental.FieldDefaults;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.function.Consumer;
+
+/**
+ * Printer used for generating Symbolic Expression (S-expression)
+ * representations of trees using an iterative approach.
+ * Note that unlike the CLI counterpart, the resulting symbolic
+ * expression does not contain the positional information of the
+ * node.
+ *
+ * @since 1.4.0
+ * @see <a href="https://github.com/tree-sitter/tree-sitter/blob/293f0d1ca30a63839810ad4b943c0f19f1cb4933/cli/src/parse.rs#L130-L184">Rust implementation</a>
+ * @author Ozren Dabić
+ */
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class SymbolicExpressionPrinter extends IterativeTreePrinter {
+
+    protected SymbolicExpressionPrinter(@NotNull TreeCursor cursor) {
+        super(cursor);
+    }
+
+    @Override
+    protected String getFileExtension() {
+        return ".scm";
+    }
+
+    protected void write(Consumer<String> appender) {
+        boolean needsSpace = false;
+        boolean visitedChildren = false;
+        for (;;) {
+            TreeCursorNode cursorNode = cursor.getCurrentTreeCursorNode();
+            boolean isNamed = cursorNode.isNamed();
+            String type = cursorNode.getType();
+            String name = cursorNode.getName();
+            if (visitedChildren) {
+                if (isNamed) {
+                    appender.accept(")");
+                    needsSpace = true;
+                }
+                if (cursor.gotoNextSibling()) visitedChildren = false;
+                else if (cursor.gotoParent()) visitedChildren = true;
+                else return;
+            } else {
+                if (isNamed) {
+                    if (needsSpace)
+                        appender.accept(" ");
+                    if (name != null) {
+                        appender.accept(name);
+                        appender.accept(": ");
+                    }
+                    appender.accept("(");
+                    appender.accept(type);
+                    needsSpace = true;
+                }
+                visitedChildren = !cursor.gotoFirstChild();
+            }
+        }
+    }
+}

--- a/src/main/java/ch/usi/si/seart/treesitter/printer/SymbolicExpressionPrinter.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/printer/SymbolicExpressionPrinter.java
@@ -22,7 +22,7 @@ import java.util.function.Consumer;
 @FieldDefaults(level = AccessLevel.PRIVATE)
 public class SymbolicExpressionPrinter extends IterativeTreePrinter {
 
-    protected SymbolicExpressionPrinter(@NotNull TreeCursor cursor) {
+    public SymbolicExpressionPrinter(@NotNull TreeCursor cursor) {
         super(cursor);
     }
 

--- a/src/main/java/ch/usi/si/seart/treesitter/printer/SyntaxTreePrinter.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/printer/SyntaxTreePrinter.java
@@ -2,8 +2,6 @@ package ch.usi.si.seart.treesitter.printer;
 
 import ch.usi.si.seart.treesitter.TreeCursor;
 import ch.usi.si.seart.treesitter.TreeCursorNode;
-import lombok.AccessLevel;
-import lombok.experimental.FieldDefaults;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.function.Consumer;
@@ -21,10 +19,7 @@ import java.util.function.Consumer;
  * @see <a href="https://tree-sitter.github.io/tree-sitter/playground">Syntax Tree Playground</a>
  * @author Ozren Dabić
  */
-@FieldDefaults(level = AccessLevel.PRIVATE)
 public class SyntaxTreePrinter extends IterativeTreePrinter {
-
-    int depth = 0;
 
     public SyntaxTreePrinter(@NotNull TreeCursor cursor) {
         super(cursor);
@@ -36,6 +31,7 @@ public class SyntaxTreePrinter extends IterativeTreePrinter {
     }
 
     protected void write(Consumer<String> appender) {
+        int depth = 0;
         for (;;) {
             TreeCursorNode cursorNode = cursor.getCurrentTreeCursorNode();
             if (cursorNode.isNamed()) {

--- a/src/main/java/ch/usi/si/seart/treesitter/printer/SyntaxTreePrinter.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/printer/SyntaxTreePrinter.java
@@ -2,19 +2,10 @@ package ch.usi.si.seart.treesitter.printer;
 
 import ch.usi.si.seart.treesitter.TreeCursor;
 import ch.usi.si.seart.treesitter.TreeCursorNode;
-import ch.usi.si.seart.treesitter.function.IOExceptionThrowingConsumer;
 import lombok.AccessLevel;
-import lombok.Cleanup;
 import lombok.experimental.FieldDefaults;
 import org.jetbrains.annotations.NotNull;
 
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.io.Writer;
-import java.nio.file.Files;
 import java.util.function.Consumer;
 
 /**
@@ -39,37 +30,12 @@ public class SyntaxTreePrinter extends IterativeTreePrinter {
         super(cursor);
     }
 
-    /**
-     * Generates a human-readable representation of the tree,
-     * starting from the node currently pointed to by the cursor.
-     *
-     * @return A human-readable print-out of the tree
-     */
     @Override
-    public String print() {
-        StringBuilder stringBuilder = new StringBuilder();
-        write(stringBuilder::append);
-        return stringBuilder.toString();
+    protected String getFileExtension() {
+        return ".txt";
     }
 
-    /**
-     * @return A file containing human-readable print-out of the tree
-     * @throws IOException if an I/O error occurs
-     */
-    @Override
-    public File export() throws IOException {
-        File file = Files.createTempFile("ts-export-", ".txt").toFile();
-        @Cleanup Writer writer = new BufferedWriter(new FileWriter(file));
-        Consumer<String> appender = IOExceptionThrowingConsumer.toUnchecked(writer::append);
-        try {
-            write(appender);
-        } catch (UncheckedIOException ex) {
-            throw ex.getCause();
-        }
-        return file;
-    }
-
-    private void write(Consumer<String> appender) {
+    protected void write(Consumer<String> appender) {
         for (;;) {
             TreeCursorNode cursorNode = cursor.getCurrentTreeCursorNode();
             if (cursorNode.isNamed()) {

--- a/src/main/java/ch/usi/si/seart/treesitter/printer/XMLPrinter.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/printer/XMLPrinter.java
@@ -3,9 +3,6 @@ package ch.usi.si.seart.treesitter.printer;
 import ch.usi.si.seart.treesitter.Point;
 import ch.usi.si.seart.treesitter.TreeCursor;
 import ch.usi.si.seart.treesitter.TreeCursorNode;
-import lombok.AccessLevel;
-import lombok.experimental.FieldDefaults;
-import lombok.experimental.NonFinal;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayDeque;
@@ -22,14 +19,9 @@ import java.util.function.Consumer;
  * @see <a href="https://github.com/tree-sitter/tree-sitter/blob/293f0d1ca30a63839810ad4b943c0f19f1cb4933/cli/src/parse.rs#L186-L239">Rust implementation</a>
  * @author Ozren Dabić
  */
-@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
 public class XMLPrinter extends IterativeTreePrinter {
 
     public static final String PROLOG = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>";
-
-    @NonFinal
-    boolean visitedChildren = false;
-    Deque<String> tags = new ArrayDeque<>();
 
     public XMLPrinter(@NotNull TreeCursor cursor) {
         super(cursor);
@@ -46,6 +38,8 @@ public class XMLPrinter extends IterativeTreePrinter {
     }
 
     protected void write(Consumer<String> appender) {
+        boolean visitedChildren = false;
+        Deque<String> tags = new ArrayDeque<>();
         for (;;) {
             TreeCursorNode cursorNode = cursor.getCurrentTreeCursorNode();
             boolean isNamed = cursorNode.isNamed();

--- a/src/main/java/ch/usi/si/seart/treesitter/printer/XMLPrinter.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/printer/XMLPrinter.java
@@ -3,20 +3,11 @@ package ch.usi.si.seart.treesitter.printer;
 import ch.usi.si.seart.treesitter.Point;
 import ch.usi.si.seart.treesitter.TreeCursor;
 import ch.usi.si.seart.treesitter.TreeCursorNode;
-import ch.usi.si.seart.treesitter.function.IOExceptionThrowingConsumer;
 import lombok.AccessLevel;
-import lombok.Cleanup;
 import lombok.experimental.FieldDefaults;
 import lombok.experimental.NonFinal;
 import org.jetbrains.annotations.NotNull;
 
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.io.Writer;
-import java.nio.file.Files;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.function.Consumer;
@@ -44,41 +35,17 @@ public class XMLPrinter extends IterativeTreePrinter {
         super(cursor);
     }
 
-    /**
-     * Generates an XML representation of the tree,
-     * starting from the node currently pointed to by the cursor.
-     *
-     * @return An XML string of the tree
-     */
     @Override
-    public String print() {
-        StringBuilder stringBuilder = new StringBuilder(PROLOG);
-        write(stringBuilder::append);
-        return stringBuilder.toString();
+    protected String getPreamble() {
+        return PROLOG;
     }
 
-    /**
-     * Generates an XML representation of the tree,
-     * writing it directly to a file.
-     *
-     * @return A file containing the XML string of the tree
-     * @throws IOException if an I/O error occurs
-     */
     @Override
-    public File export() throws IOException {
-        File file = Files.createTempFile("ts-export-", ".xml").toFile();
-        @Cleanup Writer writer = new BufferedWriter(new FileWriter(file));
-        writer.append(PROLOG);
-        Consumer<String> appender = IOExceptionThrowingConsumer.toUnchecked(writer::append);
-        try {
-            write(appender);
-        } catch (UncheckedIOException ex) {
-            throw ex.getCause();
-        }
-        return file;
+    protected String getFileExtension() {
+        return ".xml";
     }
 
-    private void write(Consumer<String> appender) {
+    protected void write(Consumer<String> appender) {
         for (;;) {
             TreeCursorNode cursorNode = cursor.getCurrentTreeCursorNode();
             boolean isNamed = cursorNode.isNamed();

--- a/src/test/java/ch/usi/si/seart/treesitter/ParserTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/ParserTest.java
@@ -25,8 +25,6 @@ class ParserTest extends TestBase {
     private static Parser parser;
 
     private static final String source = "print(\"hi\")\n";
-    private static final String nodeString =
-            "(module (expression_statement (call function: (identifier) arguments: (argument_list (string)))))";
 
     @BeforeAll
     static void beforeAll() throws IOException {
@@ -43,25 +41,43 @@ class ParserTest extends TestBase {
     @Test
     void testParseString() {
         @Cleanup Tree tree = parser.parse(source);
-        Assertions.assertEquals(nodeString, tree.getRootNode().getNodeString());
+        Assertions.assertFalse(tree.isNull());
+        Node root = tree.getRootNode();
+        Assertions.assertEquals("module", root.getType());
+        Range range = root.getRange();
+        Point start = range.getStartPoint();
+        Point end = range.getEndPoint();
+        Assertions.assertEquals(new Point(0, 0), start);
+        Assertions.assertEquals(new Point(1, 0), end);
     }
 
     @Test
     void testParseFile() {
         @Cleanup Tree tree = parser.parse(tmpFile);
-        Assertions.assertEquals(nodeString, tree.getRootNode().getNodeString());
+        Assertions.assertFalse(tree.isNull());
+        Node root = tree.getRootNode();
+        Assertions.assertEquals("module", root.getType());
+        Range range = root.getRange();
+        Point start = range.getStartPoint();
+        Point end = range.getEndPoint();
+        Assertions.assertEquals(new Point(0, 0), start);
+        Assertions.assertEquals(new Point(1, 0), end);
     }
 
     @Test
     void testParserSetLanguage() {
         @Cleanup Parser parser = new Parser(Language.PYTHON);
         parser.setLanguage(Language.JAVA);
-        String source = "public class _ {}";
+        String source = "public class _ {}\n";
         @Cleanup Tree tree = parser.parse(source);
-        Assertions.assertEquals(
-                "(program (class_declaration (modifiers) name: (identifier) body: (class_body)))",
-                tree.getRootNode().getNodeString()
-        );
+        Assertions.assertFalse(tree.isNull());
+        Node root = tree.getRootNode();
+        Assertions.assertEquals("program", root.getType());
+        Range range = root.getRange();
+        Point start = range.getStartPoint();
+        Point end = range.getEndPoint();
+        Assertions.assertEquals(new Point(0, 0), start);
+        Assertions.assertEquals(new Point(1, 0), end);
     }
 
     @Test

--- a/src/test/java/ch/usi/si/seart/treesitter/TreeTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/TreeTest.java
@@ -9,10 +9,14 @@ class TreeTest extends TestBase {
     @Test
     void testTreeEdit() {
         @Cleanup Parser parser = new Parser(Language.JAVA);
-
-        Tree tree = parser.parse("class Main {\n    // This is a line comment\n}");
-
+        Tree tree = parser.parse("class Main {\n    // This is a line comment\n}\n");
         Node root = tree.getRootNode();
+        Assertions.assertEquals("program", root.getType());
+        Range range = root.getRange();
+        Point start = range.getStartPoint();
+        Point end = range.getEndPoint();
+        Assertions.assertEquals(new Point(0, 0), start);
+        Assertions.assertEquals(new Point(3, 0), end);
         Node body = root.getChild(0).getChildByFieldName("body");
         int newEndByte = 13;
         Point newEndPoint = new Point(1, 1);
@@ -24,15 +28,15 @@ class TreeTest extends TestBase {
                 body.getEndPoint(),
                 newEndPoint
         );
-
-        String oldSExp = tree.getRootNode().getNodeString();
-
         tree.edit(inputEdit);
-
-        tree = parser.parse("class Main {\n}", tree);
-
-        String newSExp = tree.getRootNode().getNodeString();
-        Assertions.assertNotEquals(oldSExp, newSExp);
+        tree = parser.parse("class Main {\n}\n", tree);
+        root = tree.getRootNode();
+        Assertions.assertEquals("program", root.getType());
+        range = root.getRange();
+        start = range.getStartPoint();
+        end = range.getEndPoint();
+        Assertions.assertEquals(new Point(0, 0), start);
+        Assertions.assertEquals(new Point(2, 0), end);
     }
 
     @Test

--- a/src/test/java/ch/usi/si/seart/treesitter/printer/SymbolicExpressionPrinterTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/printer/SymbolicExpressionPrinterTest.java
@@ -1,0 +1,62 @@
+package ch.usi.si.seart.treesitter.printer;
+
+import ch.usi.si.seart.treesitter.TreeCursor;
+
+class SymbolicExpressionPrinterTest extends PrinterTestBase{
+
+    @Override
+    protected String getExpected() {
+        return
+                "(program " +
+                    "(package_declaration " +
+                        "(scoped_identifier " +
+                            "scope: (scoped_identifier " +
+                                "scope: (identifier) " +
+                                "name: (identifier)" +
+                            ") " +
+                            "name: (identifier)" +
+                        ")" +
+                    ") " +
+                    "(class_declaration " +
+                        "(modifiers) " +
+                        "name: (identifier) " +
+                        "body: (class_body " +
+                            "(method_declaration " +
+                                "(modifiers) " +
+                                "type: (void_type) " +
+                                "name: (identifier) " +
+                                "parameters: (formal_parameters " +
+                                    "(formal_parameter " +
+                                        "type: (array_type " +
+                                            "element: (type_identifier) " +
+                                            "dimensions: (dimensions)" +
+                                        ") " +
+                                        "name: (identifier)" +
+                                    ")" +
+                                ") " +
+                                "body: (block " +
+                                    "(line_comment) " +
+                                    "(expression_statement " +
+                                        "(method_invocation " +
+                                            "object: (field_access " +
+                                                "object: (identifier) " +
+                                                "field: (identifier)" +
+                                            ") " +
+                                            "name: (identifier) " +
+                                            "arguments: (argument_list " +
+                                                "(string_literal)" +
+                                            ")" +
+                                        ")" +
+                                    ")" +
+                                ")" +
+                            ")" +
+                        ")" +
+                    ")" +
+                ")";
+    }
+
+    @Override
+    protected TreePrinter getPrinter(TreeCursor cursor) {
+        return new SymbolicExpressionPrinter(cursor);
+    }
+}


### PR DESCRIPTION
The `getNodeString` method of `Node` has a massive flaw: it causes a premature SIGILL termination when called on very large trees. Introducing a dedicated iterative printer that fulfils the same purpose will help us mitigate this issue. While the `Node` method is unsafe, it will be deprecated for now, and subsequently removed in the next major version.