### PR TITLE
`TreeCursor` class is now `Cloneable`

### DIFF
--- a/lib/ch_usi_si_seart_treesitter_TreeCursor.cc
+++ b/lib/ch_usi_si_seart_treesitter_TreeCursor.cc
@@ -69,3 +69,19 @@ JNIEXPORT jboolean JNICALL Java_ch_usi_si_seart_treesitter_TreeCursor_gotoParent
   env->SetIntField(thisObject, _treeCursorContext1Field, cursor->context[1]);
   return result ? JNI_TRUE : JNI_FALSE;
 }
+
+JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_TreeCursor_clone(
+  JNIEnv* env, jobject thisObject) {
+  jobject treeObject = env->GetObjectField(thisObject, _treeCursorTreeField);
+  const TSTreeCursor* cursor = (const TSTreeCursor*)__getPointer(env, thisObject);
+  TSTreeCursor copy = ts_tree_cursor_copy(cursor);
+  return env->NewObject(
+    _treeCursorClass,
+    _treeCursorConstructor,
+    new TSTreeCursor(copy),
+    copy.context[0],
+    copy.context[1],
+    copy.id,
+    treeObject
+  );
+}

--- a/lib/ch_usi_si_seart_treesitter_TreeCursor.h
+++ b/lib/ch_usi_si_seart_treesitter_TreeCursor.h
@@ -63,6 +63,14 @@ JNIEXPORT jboolean JNICALL Java_ch_usi_si_seart_treesitter_TreeCursor_gotoNextSi
 JNIEXPORT jboolean JNICALL Java_ch_usi_si_seart_treesitter_TreeCursor_gotoParent
   (JNIEnv *, jobject);
 
+/*
+ * Class:     ch_usi_si_seart_treesitter_TreeCursor
+ * Method:    clone
+ * Signature: ()Lch/usi/si/seart/treesitter/TreeCursor;
+ */
+JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_TreeCursor_clone
+  (JNIEnv *, jobject);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/main/java/ch/usi/si/seart/treesitter/TreeCursor.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/TreeCursor.java
@@ -18,7 +18,7 @@ import java.util.function.Consumer;
  * @author Ozren Dabić
  */
 @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
-public class TreeCursor extends External {
+public class TreeCursor extends External implements Cloneable {
 
     int context0;
     int context1;
@@ -120,4 +120,13 @@ public class TreeCursor extends External {
     public String toString() {
         return String.format("TreeCursor(id: %d, tree: %d)", id, tree.pointer);
     }
+
+    /**
+     * Clone this cursor, creating a separate, independent instance.
+     *
+     * @return a clone of this instance
+     * @since 1.5.1
+     */
+    @Override
+    public native TreeCursor clone();
 }

--- a/src/test/java/ch/usi/si/seart/treesitter/TreeCursorTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/TreeCursorTest.java
@@ -1,5 +1,6 @@
 package ch.usi.si.seart.treesitter;
 
+import lombok.Cleanup;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -74,6 +75,12 @@ class TreeCursorTest extends TestBase {
                 count.incrementAndGet();
         });
         Assertions.assertEquals(17, count.get());
+    }
+
+    @Test
+    void testClone() {
+        @Cleanup TreeCursor copy = cursor.clone();
+        Assertions.assertNotEquals(cursor, copy);
     }
 
     @Test


### PR DESCRIPTION
The actual `clone` implementation is handled by the native code, and the dedicated tree-sitter APIs.