### PR TITLE
Adding new and improving existing member methods of `Node`

### DIFF
--- a/lib/ch_usi_si_seart_treesitter_Node.cc
+++ b/lib/ch_usi_si_seart_treesitter_Node.cc
@@ -46,8 +46,8 @@ JNIEXPORT jint JNICALL Java_ch_usi_si_seart_treesitter_Node_getChildCount(
   return (jint)count;
 }
 
-JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getDescendant__II(
-  JNIEnv* env, jobject thisObject, jint start, jint end) {
+JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getDescendant__IIZ(
+  JNIEnv* env, jobject thisObject, jint start, jint end, jboolean named) {
   if (start < 0 || end < 0) {
     env->ThrowNew(
       _illegalArgumentExceptionClass,
@@ -86,14 +86,17 @@ JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getDescendant__II
     env->Throw((jthrowable)exception);
     return NULL;
   }
-  TSNode descendant = ts_node_descendant_for_byte_range(node, rangeStart, rangeEnd);
+  TSNode (*descendant_getter)(TSNode, uint32_t, uint32_t) = (bool)named
+    ? ts_node_named_descendant_for_byte_range
+    : ts_node_descendant_for_byte_range;
+  TSNode descendant = descendant_getter(node, rangeStart, rangeEnd);
   jobject descendantObject = __marshalNode(env, descendant);
   __copyTree(env, thisObject, descendantObject);
   return descendantObject;
 }
 
-JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getDescendant__Lch_usi_si_seart_treesitter_Point_2Lch_usi_si_seart_treesitter_Point_2(
-  JNIEnv* env, jobject thisObject, jobject startPointObject, jobject endPointObject) {
+JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getDescendant__Lch_usi_si_seart_treesitter_Point_2Lch_usi_si_seart_treesitter_Point_2Z(
+  JNIEnv* env, jobject thisObject, jobject startPointObject, jobject endPointObject, jboolean named) {
   if (startPointObject == NULL) {
     env->ThrowNew(_nullPointerExceptionClass, "Start point must not be null!");
     return NULL;
@@ -127,7 +130,10 @@ JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getDescendant__Lc
     env->ThrowNew(_illegalArgumentExceptionClass, "Start point can not be greater than end point!");
     return NULL;
   }
-  TSNode descendant = ts_node_descendant_for_point_range(node, startPoint, endPoint);
+  TSNode (*descendant_getter)(TSNode, TSPoint, TSPoint) = (bool)named
+    ? ts_node_named_descendant_for_point_range
+    : ts_node_descendant_for_point_range;
+  TSNode descendant = descendant_getter(node, startPoint, endPoint);
   jobject descendantObject = __marshalNode(env, descendant);
   __copyTree(env, thisObject, descendantObject);
   return descendantObject;
@@ -205,93 +211,6 @@ JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getFirstNamedChil
   jobject childObject = __marshalNode(env, child);
   __copyTree(env, thisObject, childObject);
   return childObject;
-}
-
-JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getNamedDescendant__II(
-  JNIEnv* env, jobject thisObject, jint start, jint end) {
-  if (start < 0 || end < 0) {
-    env->ThrowNew(
-      _illegalArgumentExceptionClass,
-      "The start and end bytes must not be negative!"
-    );
-    return NULL;
-  }
-  if (start > end) {
-    env->ThrowNew(
-      _illegalArgumentExceptionClass,
-      "The starting byte of the range must not be greater than the ending byte!"
-    );
-    return NULL;
-  }
-  // Not sure why I need to multiply by two, again probably because of utf-16
-  TSNode node = __unmarshalNode(env, thisObject);
-  uint32_t nodeStart = ts_node_start_byte(node);
-  uint32_t rangeStart = (uint32_t)start * 2;
-  if (rangeStart < nodeStart) {
-    jobject exception = env->NewObject(
-      _indexOutOfBoundsExceptionClass,
-      _indexOutOfBoundsExceptionConstructor,
-      rangeStart
-    );
-    env->Throw((jthrowable)exception);
-    return NULL;
-  }
-  uint32_t nodeEnd = ts_node_end_byte(node);
-  uint32_t rangeEnd = (uint32_t)end * 2;
-  if (rangeEnd > nodeEnd) {
-    jobject exception = env->NewObject(
-      _indexOutOfBoundsExceptionClass,
-      _indexOutOfBoundsExceptionConstructor,
-      rangeEnd
-    );
-    env->Throw((jthrowable)exception);
-    return NULL;
-  }
-  TSNode descendant = ts_node_named_descendant_for_byte_range(node, rangeStart, rangeEnd);
-  jobject descendantObject = __marshalNode(env, descendant);
-  __copyTree(env, thisObject, descendantObject);
-  return descendantObject;
-}
-
-JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getNamedDescendant__Lch_usi_si_seart_treesitter_Point_2Lch_usi_si_seart_treesitter_Point_2(
-  JNIEnv* env, jobject thisObject, jobject startPointObject, jobject endPointObject) {
-  if (startPointObject == NULL) {
-    env->ThrowNew(_nullPointerExceptionClass, "Start point must not be null!");
-    return NULL;
-  }
-  if (endPointObject == NULL) {
-    env->ThrowNew(_nullPointerExceptionClass, "End point must not be null!");
-    return NULL;
-  }
-  TSNode node = __unmarshalNode(env, thisObject);
-  TSPoint startPoint = __unmarshalPoint(env, startPointObject);
-  TSPoint endPoint = __unmarshalPoint(env, endPointObject);
-  if (endPoint.row < 0 || endPoint.column < 0) {
-    env->ThrowNew(_illegalArgumentExceptionClass, "End point can not have negative coordinates!");
-    return NULL;
-  }
-  if (startPoint.row < 0 || startPoint.column < 0) {
-    env->ThrowNew(_illegalArgumentExceptionClass, "Start point can not have negative coordinates!");
-    return NULL;
-  }
-  TSPoint lowerBound = ts_node_start_point(node);
-  TSPoint upperBound = ts_node_end_point(node);
-  if (__comparePoints(lowerBound, startPoint) == GT) {
-    env->ThrowNew(_illegalArgumentExceptionClass, "Start point can not be outside of node bounds!");
-    return NULL;
-  }
-  if (__comparePoints(endPoint, upperBound) == GT) {
-    env->ThrowNew(_illegalArgumentExceptionClass, "End point can not be outside of node bounds!");
-    return NULL;
-  }
-  if (__comparePoints(startPoint, endPoint) == GT) {
-    env->ThrowNew(_illegalArgumentExceptionClass, "Start point can not be greater than end point!");
-    return NULL;
-  }
-  TSNode descendant = ts_node_named_descendant_for_point_range(node, startPoint, endPoint);
-  jobject descendantObject = __marshalNode(env, descendant);
-  __copyTree(env, thisObject, descendantObject);
-  return descendantObject;
 }
 
 JNIEXPORT jstring JNICALL Java_ch_usi_si_seart_treesitter_Node_getNodeString(

--- a/lib/ch_usi_si_seart_treesitter_Node.cc
+++ b/lib/ch_usi_si_seart_treesitter_Node.cc
@@ -46,7 +46,7 @@ JNIEXPORT jint JNICALL Java_ch_usi_si_seart_treesitter_Node_getChildCount(
   return (jint)count;
 }
 
-JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getDescendantForByteRange(
+JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getDescendant__II(
   JNIEnv* env, jobject thisObject, jint start, jint end) {
   if (start < 0 || end < 0) {
     env->ThrowNew(
@@ -92,7 +92,7 @@ JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getDescendantForB
   return descendantObject;
 }
 
-JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getDescendantForPointRange(
+JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getDescendant__Lch_usi_si_seart_treesitter_Point_2Lch_usi_si_seart_treesitter_Point_2(
   JNIEnv* env, jobject thisObject, jobject startPointObject, jobject endPointObject) {
   if (startPointObject == NULL) {
     env->ThrowNew(_nullPointerExceptionClass, "Start point must not be null!");

--- a/lib/ch_usi_si_seart_treesitter_Node.cc
+++ b/lib/ch_usi_si_seart_treesitter_Node.cc
@@ -46,6 +46,20 @@ JNIEXPORT jint JNICALL Java_ch_usi_si_seart_treesitter_Node_getChildCount(
   return (jint)count;
 }
 
+JNIEXPORT jobjectArray JNICALL Java_ch_usi_si_seart_treesitter_Node_getChildren(
+  JNIEnv* env, jclass thisClass, jobject nodeObject) {
+  TSNode node = __unmarshalNode(env, nodeObject);
+  uint32_t count = ts_node_is_null(node) ? 0 : ts_node_child_count(node);
+  jobjectArray children = env->NewObjectArray(count, _nodeClass, NULL);
+  for (int i = 0; i < count; i++) {
+    TSNode child = ts_node_child(node, i);
+    jobject childObject = __marshalNode(env, child);
+    __copyTree(env, nodeObject, childObject);
+    env->SetObjectArrayElement(children, i, childObject);
+  }
+  return children;
+}
+
 JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getDescendant__IIZ(
   JNIEnv* env, jobject thisObject, jint start, jint end, jboolean named) {
   if (start < 0 || end < 0) {

--- a/lib/ch_usi_si_seart_treesitter_Node.cc
+++ b/lib/ch_usi_si_seart_treesitter_Node.cc
@@ -207,6 +207,93 @@ JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getFirstNamedChil
   return childObject;
 }
 
+JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getNamedDescendant__II(
+  JNIEnv* env, jobject thisObject, jint start, jint end) {
+  if (start < 0 || end < 0) {
+    env->ThrowNew(
+      _illegalArgumentExceptionClass,
+      "The start and end bytes must not be negative!"
+    );
+    return NULL;
+  }
+  if (start > end) {
+    env->ThrowNew(
+      _illegalArgumentExceptionClass,
+      "The starting byte of the range must not be greater than the ending byte!"
+    );
+    return NULL;
+  }
+  // Not sure why I need to multiply by two, again probably because of utf-16
+  TSNode node = __unmarshalNode(env, thisObject);
+  uint32_t nodeStart = ts_node_start_byte(node);
+  uint32_t rangeStart = (uint32_t)start * 2;
+  if (rangeStart < nodeStart) {
+    jobject exception = env->NewObject(
+      _indexOutOfBoundsExceptionClass,
+      _indexOutOfBoundsExceptionConstructor,
+      rangeStart
+    );
+    env->Throw((jthrowable)exception);
+    return NULL;
+  }
+  uint32_t nodeEnd = ts_node_end_byte(node);
+  uint32_t rangeEnd = (uint32_t)end * 2;
+  if (rangeEnd > nodeEnd) {
+    jobject exception = env->NewObject(
+      _indexOutOfBoundsExceptionClass,
+      _indexOutOfBoundsExceptionConstructor,
+      rangeEnd
+    );
+    env->Throw((jthrowable)exception);
+    return NULL;
+  }
+  TSNode descendant = ts_node_named_descendant_for_byte_range(node, rangeStart, rangeEnd);
+  jobject descendantObject = __marshalNode(env, descendant);
+  __copyTree(env, thisObject, descendantObject);
+  return descendantObject;
+}
+
+JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getNamedDescendant__Lch_usi_si_seart_treesitter_Point_2Lch_usi_si_seart_treesitter_Point_2(
+  JNIEnv* env, jobject thisObject, jobject startPointObject, jobject endPointObject) {
+  if (startPointObject == NULL) {
+    env->ThrowNew(_nullPointerExceptionClass, "Start point must not be null!");
+    return NULL;
+  }
+  if (endPointObject == NULL) {
+    env->ThrowNew(_nullPointerExceptionClass, "End point must not be null!");
+    return NULL;
+  }
+  TSNode node = __unmarshalNode(env, thisObject);
+  TSPoint startPoint = __unmarshalPoint(env, startPointObject);
+  TSPoint endPoint = __unmarshalPoint(env, endPointObject);
+  if (endPoint.row < 0 || endPoint.column < 0) {
+    env->ThrowNew(_illegalArgumentExceptionClass, "End point can not have negative coordinates!");
+    return NULL;
+  }
+  if (startPoint.row < 0 || startPoint.column < 0) {
+    env->ThrowNew(_illegalArgumentExceptionClass, "Start point can not have negative coordinates!");
+    return NULL;
+  }
+  TSPoint lowerBound = ts_node_start_point(node);
+  TSPoint upperBound = ts_node_end_point(node);
+  if (__comparePoints(lowerBound, startPoint) == GT) {
+    env->ThrowNew(_illegalArgumentExceptionClass, "Start point can not be outside of node bounds!");
+    return NULL;
+  }
+  if (__comparePoints(endPoint, upperBound) == GT) {
+    env->ThrowNew(_illegalArgumentExceptionClass, "End point can not be outside of node bounds!");
+    return NULL;
+  }
+  if (__comparePoints(startPoint, endPoint) == GT) {
+    env->ThrowNew(_illegalArgumentExceptionClass, "Start point can not be greater than end point!");
+    return NULL;
+  }
+  TSNode descendant = ts_node_named_descendant_for_point_range(node, startPoint, endPoint);
+  jobject descendantObject = __marshalNode(env, descendant);
+  __copyTree(env, thisObject, descendantObject);
+  return descendantObject;
+}
+
 JNIEXPORT jstring JNICALL Java_ch_usi_si_seart_treesitter_Node_getNodeString(
   JNIEnv* env, jobject thisObject) {
   TSNode node = __unmarshalNode(env, thisObject);

--- a/lib/ch_usi_si_seart_treesitter_Node.h
+++ b/lib/ch_usi_si_seart_treesitter_Node.h
@@ -33,18 +33,18 @@ JNIEXPORT jint JNICALL Java_ch_usi_si_seart_treesitter_Node_getChildCount
 
 /*
  * Class:     ch_usi_si_seart_treesitter_Node
- * Method:    getDescendantForByteRange
+ * Method:    getDescendant
  * Signature: (II)Lch/usi/si/seart/treesitter/Node;
  */
-JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getDescendantForByteRange
+JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getDescendant__II
   (JNIEnv *, jobject, jint, jint);
 
 /*
  * Class:     ch_usi_si_seart_treesitter_Node
- * Method:    getDescendantForPointRange
+ * Method:    getDescendant
  * Signature: (Lch/usi/si/seart/treesitter/Point;Lch/usi/si/seart/treesitter/Point;)Lch/usi/si/seart/treesitter/Node;
  */
-JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getDescendantForPointRange
+JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getDescendant__Lch_usi_si_seart_treesitter_Point_2Lch_usi_si_seart_treesitter_Point_2
   (JNIEnv *, jobject, jobject, jobject);
 
 /*

--- a/lib/ch_usi_si_seart_treesitter_Node.h
+++ b/lib/ch_usi_si_seart_treesitter_Node.h
@@ -41,6 +41,14 @@ JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getDescendantForB
 
 /*
  * Class:     ch_usi_si_seart_treesitter_Node
+ * Method:    getDescendantForPointRange
+ * Signature: (Lch/usi/si/seart/treesitter/Point;Lch/usi/si/seart/treesitter/Point;)Lch/usi/si/seart/treesitter/Node;
+ */
+JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getDescendantForPointRange
+  (JNIEnv *, jobject, jobject, jobject);
+
+/*
+ * Class:     ch_usi_si_seart_treesitter_Node
  * Method:    getEndByte
  * Signature: ()I
  */

--- a/lib/ch_usi_si_seart_treesitter_Node.h
+++ b/lib/ch_usi_si_seart_treesitter_Node.h
@@ -34,18 +34,18 @@ JNIEXPORT jint JNICALL Java_ch_usi_si_seart_treesitter_Node_getChildCount
 /*
  * Class:     ch_usi_si_seart_treesitter_Node
  * Method:    getDescendant
- * Signature: (II)Lch/usi/si/seart/treesitter/Node;
+ * Signature: (IIZ)Lch/usi/si/seart/treesitter/Node;
  */
-JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getDescendant__II
-  (JNIEnv *, jobject, jint, jint);
+JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getDescendant__IIZ
+  (JNIEnv *, jobject, jint, jint, jboolean);
 
 /*
  * Class:     ch_usi_si_seart_treesitter_Node
  * Method:    getDescendant
- * Signature: (Lch/usi/si/seart/treesitter/Point;Lch/usi/si/seart/treesitter/Point;)Lch/usi/si/seart/treesitter/Node;
+ * Signature: (Lch/usi/si/seart/treesitter/Point;Lch/usi/si/seart/treesitter/Point;Z)Lch/usi/si/seart/treesitter/Node;
  */
-JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getDescendant__Lch_usi_si_seart_treesitter_Point_2Lch_usi_si_seart_treesitter_Point_2
-  (JNIEnv *, jobject, jobject, jobject);
+JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getDescendant__Lch_usi_si_seart_treesitter_Point_2Lch_usi_si_seart_treesitter_Point_2Z
+  (JNIEnv *, jobject, jobject, jobject, jboolean);
 
 /*
  * Class:     ch_usi_si_seart_treesitter_Node
@@ -86,22 +86,6 @@ JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getFirstChildForB
  */
 JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getFirstNamedChildForByte
   (JNIEnv *, jobject, jint);
-
-/*
- * Class:     ch_usi_si_seart_treesitter_Node
- * Method:    getNamedDescendant
- * Signature: (II)Lch/usi/si/seart/treesitter/Node;
- */
-JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getNamedDescendant__II
-  (JNIEnv *, jobject, jint, jint);
-
-/*
- * Class:     ch_usi_si_seart_treesitter_Node
- * Method:    getNamedDescendant
- * Signature: (Lch/usi/si/seart/treesitter/Point;Lch/usi/si/seart/treesitter/Point;)Lch/usi/si/seart/treesitter/Node;
- */
-JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getNamedDescendant__Lch_usi_si_seart_treesitter_Point_2Lch_usi_si_seart_treesitter_Point_2
-  (JNIEnv *, jobject, jobject, jobject);
 
 /*
  * Class:     ch_usi_si_seart_treesitter_Node

--- a/lib/ch_usi_si_seart_treesitter_Node.h
+++ b/lib/ch_usi_si_seart_treesitter_Node.h
@@ -89,6 +89,22 @@ JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getFirstNamedChil
 
 /*
  * Class:     ch_usi_si_seart_treesitter_Node
+ * Method:    getNamedDescendant
+ * Signature: (II)Lch/usi/si/seart/treesitter/Node;
+ */
+JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getNamedDescendant__II
+  (JNIEnv *, jobject, jint, jint);
+
+/*
+ * Class:     ch_usi_si_seart_treesitter_Node
+ * Method:    getNamedDescendant
+ * Signature: (Lch/usi/si/seart/treesitter/Point;Lch/usi/si/seart/treesitter/Point;)Lch/usi/si/seart/treesitter/Node;
+ */
+JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getNamedDescendant__Lch_usi_si_seart_treesitter_Point_2Lch_usi_si_seart_treesitter_Point_2
+  (JNIEnv *, jobject, jobject, jobject);
+
+/*
+ * Class:     ch_usi_si_seart_treesitter_Node
  * Method:    getNodeString
  * Signature: ()Ljava/lang/String;
  */

--- a/lib/ch_usi_si_seart_treesitter_Node.h
+++ b/lib/ch_usi_si_seart_treesitter_Node.h
@@ -33,6 +33,14 @@ JNIEXPORT jint JNICALL Java_ch_usi_si_seart_treesitter_Node_getChildCount
 
 /*
  * Class:     ch_usi_si_seart_treesitter_Node
+ * Method:    getChildren
+ * Signature: (Lch/usi/si/seart/treesitter/Node;)[Lch/usi/si/seart/treesitter/Node;
+ */
+JNIEXPORT jobjectArray JNICALL Java_ch_usi_si_seart_treesitter_Node_getChildren
+  (JNIEnv *, jclass, jobject);
+
+/*
+ * Class:     ch_usi_si_seart_treesitter_Node
  * Method:    getDescendant
  * Signature: (IIZ)Lch/usi/si/seart/treesitter/Node;
  */

--- a/src/main/java/ch/usi/si/seart/treesitter/Node.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Node.java
@@ -105,7 +105,11 @@ public class Node implements Iterable<Node> {
      * </ul>
      * @since 1.6.0
      */
-    public native Node getDescendant(int startByte, int endByte);
+    public Node getDescendant(int startByte, int endByte) {
+        return getDescendant(startByte, endByte, false);
+    }
+
+    private native Node getDescendant(int startByte, int endByte, boolean named);
 
     /**
      * Get the smallest node within this node that spans the given range of points.
@@ -121,7 +125,11 @@ public class Node implements Iterable<Node> {
      * </ul>
      * @since 1.6.0
      */
-    public native Node getDescendant(@NotNull Point startPoint, @NotNull Point endPoint);
+    public Node getDescendant(@NotNull Point startPoint, @NotNull Point endPoint) {
+        return getDescendant(startPoint, endPoint, false);
+    }
+
+    private native Node getDescendant(Point startPoint, Point endPoint, boolean named);
 
     /**
      * @return The node's end byte
@@ -174,7 +182,9 @@ public class Node implements Iterable<Node> {
      * </ul>
      * @since 1.6.0
      */
-    public native Node getNamedDescendant(int startByte, int endByte);
+    public Node getNamedDescendant(int startByte, int endByte) {
+        return getDescendant(startByte, endByte, true);
+    }
 
     /**
      * Get the smallest named node within this node that spans the given range of points.
@@ -190,7 +200,9 @@ public class Node implements Iterable<Node> {
      * </ul>
      * @since 1.6.0
      */
-    public native Node getNamedDescendant(@NotNull Point startPoint, @NotNull Point endPoint);
+    public Node getNamedDescendant(@NotNull Point startPoint, @NotNull Point endPoint) {
+        return getDescendant(startPoint, endPoint, true);
+    }
 
     /**
      * @return An S-expression representing the node as a string

--- a/src/main/java/ch/usi/si/seart/treesitter/Node.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Node.java
@@ -90,6 +90,17 @@ public class Node implements Iterable<Node> {
     public native Node getDescendantForByteRange(int startByte, int endByte);
 
     /**
+     * @param startPoint The start point of the range
+     * @param endPoint The end point of the range
+     * @return The smallest node within this node that spans the given point range
+     * @throws NullPointerException if either argument is null
+     * @throws IllegalArgumentException
+     * if {@code startPoint} is a position that comes after {@code endPoint},
+     * or if either of the two points has negative coordinates
+     */
+    public native Node getDescendantForPointRange(@NotNull Point startPoint, @NotNull Point endPoint);
+
+    /**
      * @return The node's end byte
      */
     public native int getEndByte();

--- a/src/main/java/ch/usi/si/seart/treesitter/Node.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Node.java
@@ -82,23 +82,46 @@ public class Node implements Iterable<Node> {
     }
 
     /**
-     * @param startByte The starting byte of the range
-     * @param endByte The ending byte of the range
+     * @deprecated Use {@link #getDescendant(int, int)} instead
      * @return The smallest node within this node that spans the given range of bytes
-     * @throws IllegalArgumentException if {@code startByte} &gt; {@code endByte}
      */
-    public native Node getDescendantForByteRange(int startByte, int endByte);
+    @Deprecated(since = "1.6.0", forRemoval = true)
+    public Node getDescendantForByteRange(int startByte, int endByte) {
+        return getDescendant(startByte, endByte);
+    }
 
     /**
+     * Get the smallest node within this node that spans the given range of bytes.
+     *
+     * @param startByte The start byte of the range
+     * @param endByte The end byte of the range
+     * @return A descendant node
+     * @throws IndexOutOfBoundsException if either argument is outside of this node's byte range
+     * @throws IllegalArgumentException if:
+     * <ul>
+     *     <li>{@code startByte} &lt; 0</li>
+     *     <li>{@code endByte} &lt; 0</li>
+     *     <li>{@code startByte} &gt; {@code endByte}</li>
+     * </ul>
+     * @since 1.6.0
+     */
+    public native Node getDescendant(int startByte, int endByte);
+
+    /**
+     * Get the smallest node within this node that spans the given range of points.
+     *
      * @param startPoint The start point of the range
      * @param endPoint The end point of the range
-     * @return The smallest node within this node that spans the given point range
+     * @return A descendant node
      * @throws NullPointerException if either argument is null
-     * @throws IllegalArgumentException
-     * if {@code startPoint} is a position that comes after {@code endPoint},
-     * or if either of the two points has negative coordinates
+     * @throws IllegalArgumentException if:
+     * <ul>
+     *     <li>any of the arguments is outside of this node's position range</li>
+     *     <li>{@code startPoint} is a position that comes after {@code endPoint}</li>
+     * </ul>
+     * @since 1.6.0
      */
-    public native Node getDescendantForPointRange(@NotNull Point startPoint, @NotNull Point endPoint);
+    public native Node getDescendant(@NotNull Point startPoint, @NotNull Point endPoint);
 
     /**
      * @return The node's end byte

--- a/src/main/java/ch/usi/si/seart/treesitter/Node.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Node.java
@@ -160,6 +160,39 @@ public class Node implements Iterable<Node> {
     public native Node getFirstNamedChildForByte(int offset);
 
     /**
+     * Get the smallest named node within this node that spans the given range of bytes.
+     *
+     * @param startByte The start byte of the range
+     * @param endByte The end byte of the range
+     * @return A named descendant node
+     * @throws IndexOutOfBoundsException if either argument is outside of this node's byte range
+     * @throws IllegalArgumentException if:
+     * <ul>
+     *     <li>{@code startByte} &lt; 0</li>
+     *     <li>{@code endByte} &lt; 0</li>
+     *     <li>{@code startByte} &gt; {@code endByte}</li>
+     * </ul>
+     * @since 1.6.0
+     */
+    public native Node getNamedDescendant(int startByte, int endByte);
+
+    /**
+     * Get the smallest named node within this node that spans the given range of points.
+     *
+     * @param startPoint The start point of the range
+     * @param endPoint The end point of the range
+     * @return A named descendant node
+     * @throws NullPointerException if either argument is null
+     * @throws IllegalArgumentException if:
+     * <ul>
+     *     <li>any of the arguments is outside of this node's position range</li>
+     *     <li>{@code startPoint} is a position that comes after {@code endPoint}</li>
+     * </ul>
+     * @since 1.6.0
+     */
+    public native Node getNamedDescendant(@NotNull Point startPoint, @NotNull Point endPoint);
+
+    /**
      * @return An S-expression representing the node as a string
      * @deprecated <strong>This operation is potentially unsafe for large trees</strong>
      * @see ch.usi.si.seart.treesitter.printer.SymbolicExpressionPrinter SymbolicExpressionPrinter

--- a/src/main/java/ch/usi/si/seart/treesitter/Node.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Node.java
@@ -11,8 +11,6 @@ import java.util.Deque;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 /**
  * A Node represents a single node in the syntax tree.
@@ -68,10 +66,11 @@ public class Node implements Iterable<Node> {
      * @return A list of the node's children
      */
     public List<Node> getChildren() {
-        return IntStream.range(0, getChildCount())
-                .mapToObj(this::getChild)
-                .collect(Collectors.toList());
+        Node[] children = Node.getChildren(this);
+        return List.of(children);
     }
+
+    private static native Node[] getChildren(Node node);
 
     /**
      * @return The source code content encapsulated by this node

--- a/src/main/java/ch/usi/si/seart/treesitter/OffsetTreeCursor.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/OffsetTreeCursor.java
@@ -119,8 +119,16 @@ public class OffsetTreeCursor extends TreeCursor {
         }
 
         @Override
-        public Node getDescendantForByteRange(int startByte, int endByte) {
+        public Node getDescendant(int startByte, int endByte) {
             throw new UnsupportedOperationException(UOE_MESSAGE_2);
+        }
+
+        @Override
+        public Node getDescendant(@NotNull Point startPoint, @NotNull Point endPoint) {
+            return super.getDescendant(
+                    startPoint.subtract(offset),
+                    endPoint.subtract(offset)
+            );
         }
 
         @Override

--- a/src/main/java/ch/usi/si/seart/treesitter/OffsetTreeCursor.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/OffsetTreeCursor.java
@@ -152,6 +152,19 @@ public class OffsetTreeCursor extends TreeCursor {
         }
 
         @Override
+        public Node getNamedDescendant(int startByte, int endByte) {
+            throw new UnsupportedOperationException(UOE_MESSAGE_2);
+        }
+
+        @Override
+        public Node getNamedDescendant(@NotNull Point startPoint, @NotNull Point endPoint) {
+            return super.getNamedDescendant(
+                    startPoint.subtract(offset),
+                    endPoint.subtract(offset)
+            );
+        }
+
+        @Override
         public Node getNextNamedSibling() {
             return new OffsetNode(node.getNextNamedSibling());
         }

--- a/src/test/java/ch/usi/si/seart/treesitter/NodeTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/NodeTest.java
@@ -121,11 +121,11 @@ class NodeTest extends TestBase {
         Node parameters = function.getChild(2);
         Node colon = function.getChild(3);
         Node body = function.getChild(4);
-        Assertions.assertEquals(def, root.getDescendantForByteRange(def.getStartByte(), def.getEndByte()));
-        Assertions.assertEquals(identifier, root.getDescendantForByteRange(identifier.getStartByte(), identifier.getEndByte()));
-        Assertions.assertEquals(parameters, root.getDescendantForByteRange(parameters.getStartByte(), parameters.getEndByte()));
-        Assertions.assertEquals(colon, root.getDescendantForByteRange(colon.getStartByte(), colon.getEndByte()));
-        Assertions.assertEquals(body, root.getDescendantForByteRange(body.getStartByte(), body.getEndByte()));
+        Assertions.assertEquals(def, root.getDescendant(def.getStartByte(), def.getEndByte()));
+        Assertions.assertEquals(identifier, root.getDescendant(identifier.getStartByte(), identifier.getEndByte()));
+        Assertions.assertEquals(parameters, root.getDescendant(parameters.getStartByte(), parameters.getEndByte()));
+        Assertions.assertEquals(colon, root.getDescendant(colon.getStartByte(), colon.getEndByte()));
+        Assertions.assertEquals(body, root.getDescendant(body.getStartByte(), body.getEndByte()));
     }
 
     @ParameterizedTest(name = "[{index}] {0}")
@@ -133,7 +133,7 @@ class NodeTest extends TestBase {
     void testGetDescendantForByteRangeThrows(Class<Throwable> throwableType, int startByte, int endByte) {
         Node function = root.getChild(0);
         Node identifier = function.getChild(1);
-        Assertions.assertThrows(throwableType, () -> identifier.getDescendantForByteRange(startByte, endByte));
+        Assertions.assertThrows(throwableType, () -> identifier.getDescendant(startByte, endByte));
     }
 
     @Test
@@ -144,17 +144,17 @@ class NodeTest extends TestBase {
         Node parameters = function.getChild(2);
         Node colon = function.getChild(3);
         Node body = function.getChild(4);
-        Assertions.assertEquals(def, root.getDescendantForPointRange(def.getStartPoint(), def.getEndPoint()));
-        Assertions.assertEquals(identifier, root.getDescendantForPointRange(identifier.getStartPoint(), identifier.getEndPoint()));
-        Assertions.assertEquals(parameters, root.getDescendantForPointRange(parameters.getStartPoint(), parameters.getEndPoint()));
-        Assertions.assertEquals(colon, root.getDescendantForPointRange(colon.getStartPoint(), colon.getEndPoint()));
-        Assertions.assertEquals(body, root.getDescendantForPointRange(body.getStartPoint(), body.getEndPoint()));
+        Assertions.assertEquals(def, root.getDescendant(def.getStartPoint(), def.getEndPoint()));
+        Assertions.assertEquals(identifier, root.getDescendant(identifier.getStartPoint(), identifier.getEndPoint()));
+        Assertions.assertEquals(parameters, root.getDescendant(parameters.getStartPoint(), parameters.getEndPoint()));
+        Assertions.assertEquals(colon, root.getDescendant(colon.getStartPoint(), colon.getEndPoint()));
+        Assertions.assertEquals(body, root.getDescendant(body.getStartPoint(), body.getEndPoint()));
     }
 
     @ParameterizedTest(name = "[{index}] {0}")
     @MethodSource("provideStartAndEndPoints")
     void testGetDescendantForPointRangeThrows(Class<Throwable> throwableType, Point startPoint, Point endPoint) {
-        Assertions.assertThrows(throwableType, () -> root.getDescendantForPointRange(startPoint, endPoint));
+        Assertions.assertThrows(throwableType, () -> root.getDescendant(startPoint, endPoint));
     }
 
     @Test

--- a/src/test/java/ch/usi/si/seart/treesitter/NodeTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/NodeTest.java
@@ -126,7 +126,6 @@ class NodeTest extends TestBase {
         Assertions.assertEquals(parameters, root.getDescendantForByteRange(parameters.getStartByte(), parameters.getEndByte()));
         Assertions.assertEquals(colon, root.getDescendantForByteRange(colon.getStartByte(), colon.getEndByte()));
         Assertions.assertEquals(body, root.getDescendantForByteRange(body.getStartByte(), body.getEndByte()));
-        Assertions.assertThrows(IllegalArgumentException.class, () -> root.getDescendantForByteRange(2, 0));
     }
 
     @ParameterizedTest(name = "[{index}] {0}")

--- a/src/test/java/ch/usi/si/seart/treesitter/NodeTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/NodeTest.java
@@ -42,6 +42,18 @@ class NodeTest extends TestBase {
         );
     }
 
+    public static Stream<Arguments> provideStartAndEndBytes() {
+        Node function = root.getChild(0);
+        Node identifier = function.getChild(1);
+        return Stream.of(
+                Arguments.of(IllegalArgumentException.class, -1, identifier.getEndByte()),
+                Arguments.of(IllegalArgumentException.class, identifier.getStartByte(), identifier.getEndByte() * -1),
+                Arguments.of(IllegalArgumentException.class, identifier.getEndByte(), identifier.getStartByte()),
+                Arguments.of(IndexOutOfBoundsException.class, root.getStartByte(), identifier.getEndByte()),
+                Arguments.of(IndexOutOfBoundsException.class, identifier.getStartByte(), root.getEndByte())
+        );
+    }
+
     public static Stream<Arguments> provideStartAndEndPoints() {
         Node function = root.getChild(0);
         Node identifier = function.getChild(1);
@@ -115,6 +127,14 @@ class NodeTest extends TestBase {
         Assertions.assertEquals(colon, root.getDescendantForByteRange(colon.getStartByte(), colon.getEndByte()));
         Assertions.assertEquals(body, root.getDescendantForByteRange(body.getStartByte(), body.getEndByte()));
         Assertions.assertThrows(IllegalArgumentException.class, () -> root.getDescendantForByteRange(2, 0));
+    }
+
+    @ParameterizedTest(name = "[{index}] {0}")
+    @MethodSource("provideStartAndEndBytes")
+    void testGetDescendantForByteRangeThrows(Class<Throwable> throwableType, int startByte, int endByte) {
+        Node function = root.getChild(0);
+        Node identifier = function.getChild(1);
+        Assertions.assertThrows(throwableType, () -> identifier.getDescendantForByteRange(startByte, endByte));
     }
 
     @Test

--- a/src/test/java/ch/usi/si/seart/treesitter/NodeTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/NodeTest.java
@@ -230,12 +230,6 @@ class NodeTest extends TestBase {
     }
 
     @Test
-    void testGetParent() {
-        Assertions.assertNull(root.getParent());
-        Assertions.assertEquals(root, root.getChild(0).getParent());
-    }
-
-    @Test
     void testGetNextNamedSibling() {
         Node function = root.getChild(0);
         Node def = function.getChild(0);
@@ -251,6 +245,12 @@ class NodeTest extends TestBase {
         Node identifier = function.getChild(1);
         Assertions.assertNull(root.getNextSibling());
         Assertions.assertEquals(identifier, def.getNextSibling());
+    }
+
+    @Test
+    void testGetParent() {
+        Assertions.assertNull(root.getParent());
+        Assertions.assertEquals(root, root.getChild(0).getParent());
     }
 
     @Test

--- a/src/test/java/ch/usi/si/seart/treesitter/NodeTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/NodeTest.java
@@ -230,6 +230,38 @@ class NodeTest extends TestBase {
     }
 
     @Test
+    void testGetNamedDescendantForByteRange() {
+        Node function = root.getChild(0);
+        Node identifier = function.getChild(1);
+        int startByte = identifier.getStartByte();
+        int endByte = identifier.getEndByte();
+        Assertions.assertEquals(identifier, root.getNamedDescendant(startByte, endByte));
+    }
+
+    @ParameterizedTest(name = "[{index}] {0}")
+    @MethodSource("provideStartAndEndBytes")
+    void testGetNamedDescendantForByteRangeThrows(Class<Throwable> throwableType, int startByte, int endByte) {
+        Node function = root.getChild(0);
+        Node identifier = function.getChild(1);
+        Assertions.assertThrows(throwableType, () -> identifier.getNamedDescendant(startByte, endByte));
+    }
+
+    @Test
+    void testGetNamedDescendantForPointRange() {
+        Node function = root.getChild(0);
+        Node identifier = function.getChild(1);
+        Point startPoint = identifier.getStartPoint();
+        Point endPoint = identifier.getEndPoint();
+        Assertions.assertEquals(identifier, root.getNamedDescendant(startPoint, endPoint));
+    }
+
+    @ParameterizedTest(name = "[{index}] {0}")
+    @MethodSource("provideStartAndEndPoints")
+    void testGetNamedDescendantForPointRangeThrows(Class<Throwable> throwableType, Point startPoint, Point endPoint) {
+        Assertions.assertThrows(throwableType, () -> root.getDescendant(startPoint, endPoint));
+    }
+
+    @Test
     void testGetNextNamedSibling() {
         Node function = root.getChild(0);
         Node def = function.getChild(0);

--- a/src/test/java/ch/usi/si/seart/treesitter/NodeTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/NodeTest.java
@@ -42,6 +42,18 @@ class NodeTest extends TestBase {
         );
     }
 
+    public static Stream<Arguments> provideStartAndEndPoints() {
+        Node function = root.getChild(0);
+        Node identifier = function.getChild(1);
+        return Stream.of(
+                Arguments.of(NullPointerException.class, null, new Point(0, 0)),
+                Arguments.of(NullPointerException.class, new Point(0, 0), null),
+                Arguments.of(IllegalArgumentException.class, new Point(-1, -1), root.getEndPoint()),
+                Arguments.of(IllegalArgumentException.class, root.getStartPoint(), new Point(3, 1)),
+                Arguments.of(IllegalArgumentException.class, identifier.getEndPoint(), identifier.getStartPoint())
+        );
+    }
+
     @Test
     void testGetChildCount() {
         Assertions.assertEquals(1, root.getChildCount());
@@ -103,6 +115,27 @@ class NodeTest extends TestBase {
         Assertions.assertEquals(colon, root.getDescendantForByteRange(colon.getStartByte(), colon.getEndByte()));
         Assertions.assertEquals(body, root.getDescendantForByteRange(body.getStartByte(), body.getEndByte()));
         Assertions.assertThrows(IllegalArgumentException.class, () -> root.getDescendantForByteRange(2, 0));
+    }
+
+    @Test
+    void testGetDescendantForPointRange() {
+        Node function = root.getChild(0);
+        Node def = function.getChild(0);
+        Node identifier = function.getChild(1);
+        Node parameters = function.getChild(2);
+        Node colon = function.getChild(3);
+        Node body = function.getChild(4);
+        Assertions.assertEquals(def, root.getDescendantForPointRange(def.getStartPoint(), def.getEndPoint()));
+        Assertions.assertEquals(identifier, root.getDescendantForPointRange(identifier.getStartPoint(), identifier.getEndPoint()));
+        Assertions.assertEquals(parameters, root.getDescendantForPointRange(parameters.getStartPoint(), parameters.getEndPoint()));
+        Assertions.assertEquals(colon, root.getDescendantForPointRange(colon.getStartPoint(), colon.getEndPoint()));
+        Assertions.assertEquals(body, root.getDescendantForPointRange(body.getStartPoint(), body.getEndPoint()));
+    }
+
+    @ParameterizedTest(name = "[{index}] {0}")
+    @MethodSource("provideStartAndEndPoints")
+    void testGetDescendantForPointRangeThrows(Class<Throwable> throwableType, Point startPoint, Point endPoint) {
+        Assertions.assertThrows(throwableType, () -> root.getDescendantForPointRange(startPoint, endPoint));
     }
 
     @Test


### PR DESCRIPTION
Methods that have been added:
- `getDescendant`
- `getNamedDescendant`

Both methods take in as argument a byte or `Point` range to search for the descendants. Note that the existing `getDescendantForByteRange` method will be deprecated in favour of the new additions. Apart from that, changes have been made to `getChildren` in order to reduce the number of native code calls from _n_ to 1.