### PR TITLE
Added `NodeRangeBoundaryException` hierarchy

### DIFF
--- a/lib/ch_usi_si_seart_treesitter.cc
+++ b/lib/ch_usi_si_seart_treesitter.cc
@@ -123,6 +123,11 @@ jmethodID _indexOutOfBoundsExceptionConstructor;
 
 jclass _treeSitterExceptionClass;
 
+jclass _byteOffsetOutOfBoundsExceptionClass;
+jmethodID _byteOffsetOutOfBoundsExceptionConstructor;
+jclass _pointOutOfBoundsExceptionClass;
+jmethodID _pointOutOfBoundsExceptionConstructor;
+
 jclass _querySyntaxExceptionClass;
 jmethodID _querySyntaxExceptionConstructor;
 jclass _queryNodeTypeExceptionClass;
@@ -272,6 +277,12 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved) {
 
   _loadClass(_treeSitterExceptionClass, "ch/usi/si/seart/treesitter/exception/TreeSitterException")
 
+  _loadClass(_byteOffsetOutOfBoundsExceptionClass, "ch/usi/si/seart/treesitter/exception/ByteOffsetOutOfBoundsException")
+  _loadConstructor(_byteOffsetOutOfBoundsExceptionConstructor, _byteOffsetOutOfBoundsExceptionClass, "(I)V")
+  _loadClass(_pointOutOfBoundsExceptionClass, "ch/usi/si/seart/treesitter/exception/PointOutOfBoundsException")
+  _loadConstructor(_pointOutOfBoundsExceptionConstructor, _pointOutOfBoundsExceptionClass,
+    "(Lch/usi/si/seart/treesitter/Point;)V")
+
   _loadClass(_querySyntaxExceptionClass, "ch/usi/si/seart/treesitter/exception/query/QuerySyntaxException")
   _loadConstructor(_querySyntaxExceptionConstructor, _querySyntaxExceptionClass, "(I)V")
   _loadClass(_queryNodeTypeExceptionClass, "ch/usi/si/seart/treesitter/exception/query/QueryNodeTypeException")
@@ -325,6 +336,8 @@ void JNI_OnUnload(JavaVM* vm, void* reserved) {
   _unload(_timeoutExceptionClass)
   _unload(_indexOutOfBoundsExceptionClass)
   _unload(_treeSitterExceptionClass)
+  _unload(_byteOffsetOutOfBoundsExceptionClass)
+  _unload(_pointOutOfBoundsExceptionClass)
   _unload(_querySyntaxExceptionClass)
   _unload(_queryNodeTypeExceptionClass)
   _unload(_queryFieldExceptionClass)

--- a/lib/ch_usi_si_seart_treesitter.cc
+++ b/lib/ch_usi_si_seart_treesitter.cc
@@ -376,6 +376,24 @@ jint __throwIOB(JNIEnv* env, jint index) {
   return env->Throw((jthrowable)exception);
 }
 
+jint __throwBOB(JNIEnv* env, jint index) {
+  jobject exception = env->NewObject(
+    _byteOffsetOutOfBoundsExceptionClass,
+    _byteOffsetOutOfBoundsExceptionConstructor,
+    index
+  );
+  return env->Throw((jthrowable)exception);
+}
+
+jint __throwPOB(JNIEnv* env, jobject pointObject) {
+  jobject exception = env->NewObject(
+    _pointOutOfBoundsExceptionClass,
+    _pointOutOfBoundsExceptionConstructor,
+    pointObject
+  );
+  return env->Throw((jthrowable)exception);
+}
+
 jint __throwILE(JNIEnv* env, jobject languageObject) {
   jobject exception = env->NewObject(
     _incompatibleLanguageExceptionClass,

--- a/lib/ch_usi_si_seart_treesitter.h
+++ b/lib/ch_usi_si_seart_treesitter.h
@@ -124,6 +124,11 @@ extern jmethodID _treeCursorConstructor;
 
 extern jclass _treeSitterExceptionClass;
 
+extern jclass _byteOffsetOutOfBoundsExceptionClass;
+extern jmethodID _byteOffsetOutOfBoundsExceptionConstructor;
+extern jclass _pointOutOfBoundsExceptionClass;
+extern jmethodID _pointOutOfBoundsExceptionConstructor;
+
 extern jclass _querySyntaxExceptionClass;
 extern jmethodID _querySyntaxExceptionConstructor;
 extern jclass _queryNodeTypeExceptionClass;

--- a/lib/ch_usi_si_seart_treesitter.h
+++ b/lib/ch_usi_si_seart_treesitter.h
@@ -226,6 +226,10 @@ jint __throwIOE(JNIEnv* env, const char* message);
 
 jint __throwIOB(JNIEnv* env, jint index);
 
+jint __throwBOB(JNIEnv* env, jint index);
+
+jint __throwPOB(JNIEnv* env, jobject pointObject);
+
 jint __throwILE(JNIEnv* env, jobject languageObject);
 
 jlong __getPointer(JNIEnv* env, jobject objectInstance);

--- a/lib/ch_usi_si_seart_treesitter_Node.cc
+++ b/lib/ch_usi_si_seart_treesitter_Node.cc
@@ -70,13 +70,13 @@ JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getDescendant__II
   uint32_t nodeStart = ts_node_start_byte(node);
   uint32_t rangeStart = (uint32_t)start * 2;
   if (rangeStart < nodeStart) {
-    __throwIOB(env, start);
+    __throwBOB(env, start);
     return NULL;
   }
   uint32_t nodeEnd = ts_node_end_byte(node);
   uint32_t rangeEnd = (uint32_t)end * 2;
   if (rangeEnd > nodeEnd) {
-    __throwIOB(env, end);
+    __throwBOB(env, end);
     return NULL;
   }
   TSNode (*descendant_getter)(TSNode, uint32_t, uint32_t) = (bool)named
@@ -109,18 +109,18 @@ JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getDescendant__Lc
     __throwIAE(env, "Start point can not have negative coordinates!");
     return NULL;
   }
-  TSPoint lowerBound = ts_node_start_point(node);
-  TSPoint upperBound = ts_node_end_point(node);
-  if (__comparePoints(lowerBound, startPoint) == GT) {
-    __throwIAE(env, "Start point can not be outside of node bounds!");
-    return NULL;
-  }
-  if (__comparePoints(endPoint, upperBound) == GT) {
-    __throwIAE(env, "End point can not be outside of node bounds!");
-    return NULL;
-  }
   if (__comparePoints(startPoint, endPoint) == GT) {
     __throwIAE(env, "Start point can not be greater than end point!");
+    return NULL;
+  }
+  TSPoint lowerBound = ts_node_start_point(node);
+  if (__comparePoints(lowerBound, startPoint) == GT) {
+    __throwPOB(env, startPointObject);
+    return NULL;
+  }
+  TSPoint upperBound = ts_node_end_point(node);
+  if (__comparePoints(endPoint, upperBound) == GT) {
+    __throwPOB(env, endPointObject);
     return NULL;
   }
   TSNode (*descendant_getter)(TSNode, TSPoint, TSPoint) = (bool)named
@@ -166,7 +166,7 @@ JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getFirstChildForB
   uint32_t nodeStart = ts_node_start_byte(node);
   uint32_t nodeEnd = ts_node_end_byte(node);
   if ((position < nodeStart) || (position > nodeEnd)) {
-    __throwIOB(env, offset);
+    __throwBOB(env, offset);
     return NULL;
   }
   TSNode child = ts_node_first_child_for_byte(node, position);
@@ -182,7 +182,7 @@ JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getFirstNamedChil
   uint32_t nodeStart = ts_node_start_byte(node);
   uint32_t nodeEnd = ts_node_end_byte(node);
   if ((position < nodeStart) || (position > nodeEnd)) {
-    __throwIOB(env, offset);
+    __throwBOB(env, offset);
     return NULL;
   }
   TSNode child = ts_node_first_named_child_for_byte(node, position);

--- a/lib/ch_usi_si_seart_treesitter_TreeCursor.cc
+++ b/lib/ch_usi_si_seart_treesitter_TreeCursor.cc
@@ -65,12 +65,12 @@ JNIEXPORT jboolean JNICALL Java_ch_usi_si_seart_treesitter_TreeCursor_gotoFirstC
   TSNode node = ts_tree_cursor_current_node(cursor);
   uint32_t nodeStart = ts_node_start_byte(node);
   if (childStart < nodeStart) {
-    __throwIOB(env, offset);
+    __throwBOB(env, offset);
     return JNI_FALSE;
   }
   uint32_t nodeEnd = ts_node_end_byte(node);
   if (childStart > nodeEnd) {
-    __throwIOB(env, offset);
+    __throwBOB(env, offset);
     return JNI_FALSE;
   }
   int64_t result = ts_tree_cursor_goto_first_child_for_byte(cursor, childStart);
@@ -94,12 +94,12 @@ JNIEXPORT jboolean JNICALL Java_ch_usi_si_seart_treesitter_TreeCursor_gotoFirstC
   TSNode node = ts_tree_cursor_current_node(cursor);
   TSPoint lowerBound = ts_node_start_point(node);
   if (__comparePoints(lowerBound, point) == GT) {
-    __throwIAE(env, "Point can not be outside of current node bounds!");
+    __throwPOB(env, pointObject);
     return JNI_FALSE;
   }
   TSPoint upperBound = ts_node_end_point(node);
   if (__comparePoints(point, upperBound) == GT) {
-    __throwIAE(env, "Point can not be outside of current node bounds!");
+    __throwPOB(env, pointObject);
     return JNI_FALSE;
   }
   int64_t result = ts_tree_cursor_goto_first_child_for_point(cursor, point);

--- a/src/main/java/ch/usi/si/seart/treesitter/Node.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Node.java
@@ -95,7 +95,8 @@ public class Node implements Iterable<Node> {
      * @param startByte The start byte of the range
      * @param endByte The end byte of the range
      * @return A descendant node
-     * @throws IndexOutOfBoundsException if either argument is outside of this node's byte range
+     * @throws ch.usi.si.seart.treesitter.exception.ByteOffsetOutOfBoundsException
+     * if either argument is outside of this node's byte range
      * @throws IllegalArgumentException if:
      * <ul>
      *     <li>{@code startByte} &lt; 0</li>
@@ -117,11 +118,10 @@ public class Node implements Iterable<Node> {
      * @param endPoint The end point of the range
      * @return A descendant node
      * @throws NullPointerException if either argument is null
-     * @throws IllegalArgumentException if:
-     * <ul>
-     *     <li>any of the arguments is outside of this node's position range</li>
-     *     <li>{@code startPoint} is a position that comes after {@code endPoint}</li>
-     * </ul>
+     * @throws IllegalArgumentException if any point coordinates are negative,
+     * or if {@code startPoint} is a position that comes after {@code endPoint}
+     * @throws ch.usi.si.seart.treesitter.exception.PointOutOfBoundsException
+     * if any of the arguments is outside of this node's position range
      * @since 1.6.0
      */
     public Node getDescendant(@NotNull Point startPoint, @NotNull Point endPoint) {
@@ -155,14 +155,16 @@ public class Node implements Iterable<Node> {
     /**
      * @param offset The offset in bytes
      * @return The node's first child that extends beyond the given byte offset
-     * @throws IndexOutOfBoundsException if the byte offset is outside the node's byte range
+     * @throws ch.usi.si.seart.treesitter.exception.ByteOffsetOutOfBoundsException
+     * if the byte offset is outside the node's byte range
      */
     public native Node getFirstChildForByte(int offset);
 
     /**
      * @param offset The offset in bytes
      * @return The node's first named child that extends beyond the given byte offset
-     * @throws IndexOutOfBoundsException if the byte offset is outside the node's byte range
+     * @throws ch.usi.si.seart.treesitter.exception.ByteOffsetOutOfBoundsException
+     * if the byte offset is outside the node's byte range
      */
     public native Node getFirstNamedChildForByte(int offset);
 
@@ -172,7 +174,8 @@ public class Node implements Iterable<Node> {
      * @param startByte The start byte of the range
      * @param endByte The end byte of the range
      * @return A named descendant node
-     * @throws IndexOutOfBoundsException if either argument is outside of this node's byte range
+     * @throws ch.usi.si.seart.treesitter.exception.ByteOffsetOutOfBoundsException
+     * if either argument is outside of this node's byte range
      * @throws IllegalArgumentException if:
      * <ul>
      *     <li>{@code startByte} &lt; 0</li>
@@ -192,11 +195,10 @@ public class Node implements Iterable<Node> {
      * @param endPoint The end point of the range
      * @return A named descendant node
      * @throws NullPointerException if either argument is null
-     * @throws IllegalArgumentException if:
-     * <ul>
-     *     <li>any of the arguments is outside of this node's position range</li>
-     *     <li>{@code startPoint} is a position that comes after {@code endPoint}</li>
-     * </ul>
+     * @throws IllegalArgumentException if any point coordinates are negative,
+     * or if {@code startPoint} is a position that comes after {@code endPoint}
+     * @throws ch.usi.si.seart.treesitter.exception.PointOutOfBoundsException
+     * if any of the arguments is outside of this node's position range
      * @since 1.6.0
      */
     public Node getNamedDescendant(@NotNull Point startPoint, @NotNull Point endPoint) {

--- a/src/main/java/ch/usi/si/seart/treesitter/TreeCursor.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/TreeCursor.java
@@ -83,8 +83,8 @@ public class TreeCursor extends External implements Cloneable {
      * @return true if the cursor successfully moved,
      * and false if no such child was found
      * @throws IllegalArgumentException if {@code offset} is negative
-     * @throws IndexOutOfBoundsException if {@code offset} is outside
-     * the current node's byte range
+     * @throws ch.usi.si.seart.treesitter.exception.ByteOffsetOutOfBoundsException
+     * if {@code offset} is outside the current node's byte range
      * @since 1.7.0
      */
     public native boolean gotoFirstChild(int offset);
@@ -97,8 +97,8 @@ public class TreeCursor extends External implements Cloneable {
      * @return true if the cursor successfully moved,
      * and false if no such child was found
      * @throws NullPointerException if {@code point} is null
-     * @throws IllegalArgumentException if {@code point} is
-     * outside the current node's positional span
+     * @throws ch.usi.si.seart.treesitter.exception.PointOutOfBoundsException
+     * if {@code point} is outside the current node's positional span
      * @since 1.7.0
      */
     public native boolean gotoFirstChild(@NotNull Point point);

--- a/src/main/java/ch/usi/si/seart/treesitter/exception/ByteOffsetOutOfBoundsException.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/exception/ByteOffsetOutOfBoundsException.java
@@ -1,0 +1,15 @@
+package ch.usi.si.seart.treesitter.exception;
+
+/**
+ * Thrown to indicate that a specified byte offset is outside a node's byte range.
+ *
+ * @since 1.7.0
+ * @author Ozren Dabić
+ */
+public class ByteOffsetOutOfBoundsException extends NodeRangeBoundaryException {
+
+    @SuppressWarnings("unused")
+    public ByteOffsetOutOfBoundsException(int offset) {
+        super("Byte offset outside node range: " + offset);
+    }
+}

--- a/src/main/java/ch/usi/si/seart/treesitter/exception/ByteOffsetOutOfBoundsException.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/exception/ByteOffsetOutOfBoundsException.java
@@ -8,7 +8,6 @@ package ch.usi.si.seart.treesitter.exception;
  */
 public class ByteOffsetOutOfBoundsException extends NodeRangeBoundaryException {
 
-    @SuppressWarnings("unused")
     public ByteOffsetOutOfBoundsException(int offset) {
         super("Byte offset outside node range: " + offset);
     }

--- a/src/main/java/ch/usi/si/seart/treesitter/exception/NodeRangeBoundaryException.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/exception/NodeRangeBoundaryException.java
@@ -1,0 +1,14 @@
+package ch.usi.si.seart.treesitter.exception;
+
+import lombok.AccessLevel;
+import lombok.experimental.StandardException;
+
+/**
+ * The base exception type for all exceptions involving invalid node positional offsets.
+ *
+ * @since 1.7.0
+ * @author Ozren Dabić
+ */
+@StandardException(access = AccessLevel.PROTECTED)
+abstract class NodeRangeBoundaryException extends TreeSitterException {
+}

--- a/src/main/java/ch/usi/si/seart/treesitter/exception/PointOutOfBoundsException.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/exception/PointOutOfBoundsException.java
@@ -1,0 +1,17 @@
+package ch.usi.si.seart.treesitter.exception;
+
+import ch.usi.si.seart.treesitter.Point;
+
+/**
+ * Thrown to indicate that a specified point is outside a node's point range.
+ *
+ * @since 1.7.0
+ * @author Ozren Dabić
+ */
+public class PointOutOfBoundsException extends NodeRangeBoundaryException {
+
+    @SuppressWarnings("unused")
+    public PointOutOfBoundsException(Point point) {
+        super("Point outside node range: " + point);
+    }
+}

--- a/src/main/java/ch/usi/si/seart/treesitter/exception/PointOutOfBoundsException.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/exception/PointOutOfBoundsException.java
@@ -10,7 +10,6 @@ import ch.usi.si.seart.treesitter.Point;
  */
 public class PointOutOfBoundsException extends NodeRangeBoundaryException {
 
-    @SuppressWarnings("unused")
     public PointOutOfBoundsException(Point point) {
         super("Point outside node range: " + point);
     }

--- a/src/test/java/ch/usi/si/seart/treesitter/NodeTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/NodeTest.java
@@ -1,5 +1,7 @@
 package ch.usi.si.seart.treesitter;
 
+import ch.usi.si.seart.treesitter.exception.ByteOffsetOutOfBoundsException;
+import ch.usi.si.seart.treesitter.exception.PointOutOfBoundsException;
 import lombok.Cleanup;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
@@ -49,8 +51,8 @@ class NodeTest extends TestBase {
                 Arguments.of(IllegalArgumentException.class, -1, identifier.getEndByte()),
                 Arguments.of(IllegalArgumentException.class, identifier.getStartByte(), identifier.getEndByte() * -1),
                 Arguments.of(IllegalArgumentException.class, identifier.getEndByte(), identifier.getStartByte()),
-                Arguments.of(IndexOutOfBoundsException.class, root.getStartByte(), identifier.getEndByte()),
-                Arguments.of(IndexOutOfBoundsException.class, identifier.getStartByte(), root.getEndByte())
+                Arguments.of(ByteOffsetOutOfBoundsException.class, root.getStartByte(), identifier.getEndByte()),
+                Arguments.of(ByteOffsetOutOfBoundsException.class, identifier.getStartByte(), root.getEndByte())
         );
     }
 
@@ -61,8 +63,8 @@ class NodeTest extends TestBase {
                 Arguments.of(NullPointerException.class, null, new Point(0, 0)),
                 Arguments.of(NullPointerException.class, new Point(0, 0), null),
                 Arguments.of(IllegalArgumentException.class, new Point(-1, -1), root.getEndPoint()),
-                Arguments.of(IllegalArgumentException.class, root.getStartPoint(), new Point(3, 1)),
-                Arguments.of(IllegalArgumentException.class, identifier.getEndPoint(), identifier.getStartPoint())
+                Arguments.of(IllegalArgumentException.class, identifier.getEndPoint(), identifier.getStartPoint()),
+                Arguments.of(PointOutOfBoundsException.class, root.getStartPoint(), new Point(3, 1))
         );
     }
 
@@ -205,7 +207,7 @@ class NodeTest extends TestBase {
     @ParameterizedTest
     @MethodSource("provideOutOfBoundsIndexes")
     void testGetFirstChildForByteThrows(int index) {
-        Assertions.assertThrows(IndexOutOfBoundsException.class, () -> root.getFirstChildForByte(index));
+        Assertions.assertThrows(ByteOffsetOutOfBoundsException.class, () -> root.getFirstChildForByte(index));
     }
 
     @Test
@@ -226,7 +228,7 @@ class NodeTest extends TestBase {
     @ParameterizedTest
     @MethodSource("provideOutOfBoundsIndexes")
     void testGetFirstNamedChildForByteThrows(int index) {
-        Assertions.assertThrows(IndexOutOfBoundsException.class, () -> root.getFirstNamedChildForByte(index));
+        Assertions.assertThrows(ByteOffsetOutOfBoundsException.class, () -> root.getFirstNamedChildForByte(index));
     }
 
     @Test

--- a/src/test/java/ch/usi/si/seart/treesitter/TreeCursorTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/TreeCursorTest.java
@@ -1,5 +1,7 @@
 package ch.usi.si.seart.treesitter;
 
+import ch.usi.si.seart.treesitter.exception.ByteOffsetOutOfBoundsException;
+import ch.usi.si.seart.treesitter.exception.PointOutOfBoundsException;
 import lombok.Cleanup;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -85,8 +87,8 @@ class TreeCursorTest extends TestBase {
         cursor.gotoFirstChild(); // identifier
         cursor.gotoNextSibling(); // parameters
         Assertions.assertThrows(IllegalArgumentException.class, () -> cursor.gotoFirstChild(-1));
-        Assertions.assertThrows(IndexOutOfBoundsException.class, () -> cursor.gotoFirstChild(0));
-        Assertions.assertThrows(IndexOutOfBoundsException.class, () -> cursor.gotoFirstChild(20));
+        Assertions.assertThrows(ByteOffsetOutOfBoundsException.class, () -> cursor.gotoFirstChild(0));
+        Assertions.assertThrows(ByteOffsetOutOfBoundsException.class, () -> cursor.gotoFirstChild(20));
     }
 
     @Test
@@ -109,9 +111,9 @@ class TreeCursorTest extends TestBase {
         Point negative = new Point(0, -1);
         Point illegal = new Point(1, 2);
         Assertions.assertThrows(NullPointerException.class, () -> cursor.gotoFirstChild(null));
-        Assertions.assertThrows(IllegalArgumentException.class, () -> cursor.gotoFirstChild(negative));
-        Assertions.assertThrows(IllegalArgumentException.class, () -> cursor.gotoFirstChild(_0_0_));
-        Assertions.assertThrows(IllegalArgumentException.class, () -> cursor.gotoFirstChild(illegal));
+        Assertions.assertThrows(PointOutOfBoundsException.class, () -> cursor.gotoFirstChild(negative));
+        Assertions.assertThrows(PointOutOfBoundsException.class, () -> cursor.gotoFirstChild(_0_0_));
+        Assertions.assertThrows(PointOutOfBoundsException.class, () -> cursor.gotoFirstChild(illegal));
 
     }
 


### PR DESCRIPTION
This includes two new concrete exceptions:
- `ByteOffsetOutOfBoundsException`
- `PointOutOfBoundsException`

These additions affect the following methods:
- `Node`
  -  `getDescendant`
  -  `getNamedDescendant`
  -  `getFirstChildForByte`
  -  `getFirstNamedChildForByte`
- `TreeCursor`
  - `gotoFirstChild`