### PR TITLE
Removing deprecated members (<= 1.4.0)

### DIFF
--- a/lib/ch_usi_si_seart_treesitter_Node.cc
+++ b/lib/ch_usi_si_seart_treesitter_Node.cc
@@ -182,15 +182,6 @@ JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getFirstChildForB
   return childObject;
 }
 
-JNIEXPORT jstring JNICALL Java_ch_usi_si_seart_treesitter_Node_getNodeString(
-  JNIEnv* env, jobject thisObject) {
-  TSNode node = __unmarshalNode(env, thisObject);
-  char* nodeString = ts_node_string(node);
-  jstring result = env->NewStringUTF(nodeString);
-  free(nodeString);
-  return result;
-}
-
 JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getNextNamedSibling(
   JNIEnv* env, jobject thisObject) {
   TSNode node = __unmarshalNode(env, thisObject);

--- a/lib/ch_usi_si_seart_treesitter_Node.h
+++ b/lib/ch_usi_si_seart_treesitter_Node.h
@@ -89,14 +89,6 @@ JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getFirstChildForB
 
 /*
  * Class:     ch_usi_si_seart_treesitter_Node
- * Method:    getNodeString
- * Signature: ()Ljava/lang/String;
- */
-JNIEXPORT jstring JNICALL Java_ch_usi_si_seart_treesitter_Node_getNodeString
-  (JNIEnv *, jobject);
-
-/*
- * Class:     ch_usi_si_seart_treesitter_Node
  * Method:    getNextNamedSibling
  * Signature: ()Lch/usi/si/seart/treesitter/Node;
  */

--- a/src/main/java/ch/usi/si/seart/treesitter/Node.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Node.java
@@ -212,14 +212,6 @@ public class Node implements Iterable<Node> {
     }
 
     /**
-     * @return An S-expression representing the node as a string
-     * @deprecated <strong>This operation is potentially unsafe for large trees</strong>
-     * @see ch.usi.si.seart.treesitter.printer.SymbolicExpressionPrinter SymbolicExpressionPrinter
-     */
-    @Deprecated(since = "1.4.0", forRemoval = true)
-    public native String getNodeString();
-
-    /**
      * @return The node's next <em>named</em> sibling
      */
     public native Node getNextNamedSibling();


### PR DESCRIPTION
Only `getNodeString` from `Node` is removed