### PR TITLE
Enhancements to `Parser.Builder` API

### DIFF
--- a/lib/ch_usi_si_seart_treesitter_Parser_Builder.cc
+++ b/lib/ch_usi_si_seart_treesitter_Parser_Builder.cc
@@ -4,7 +4,7 @@
 #include <tree_sitter/api.h>
 
 JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Parser_00024Builder_build(
-  JNIEnv* env, jclass thisClass, jobject languageObject) {
+  JNIEnv* env, jclass thisClass, jobject languageObject, jlong timeout) {
   TSParser* parser = ts_parser_new();
   const TSLanguage* language = __unmarshalLanguage(env, languageObject);
   bool succeeded = ts_parser_set_language(parser, language);
@@ -12,6 +12,13 @@ JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Parser_00024Builder_bu
     ts_parser_delete(parser);
     __throwILE(env, languageObject);
     return NULL;
+  }
+  if (timeout < 0) {
+    ts_parser_delete(parser);
+    __throwIAE(env, "Timeout can not be negative!");
+    return NULL;
+  } else if (timeout > 0) {
+    ts_parser_set_timeout_micros(parser, (uint64_t)timeout);
   }
   return env->NewObject(
     _parserClass,

--- a/lib/ch_usi_si_seart_treesitter_Parser_Builder.h
+++ b/lib/ch_usi_si_seart_treesitter_Parser_Builder.h
@@ -10,10 +10,10 @@ extern "C" {
 /*
  * Class:     ch_usi_si_seart_treesitter_Parser_Builder
  * Method:    build
- * Signature: (Lch/usi/si/seart/treesitter/Language;)Lch/usi/si/seart/treesitter/Parser;
+ * Signature: (Lch/usi/si/seart/treesitter/Language;J)Lch/usi/si/seart/treesitter/Parser;
  */
 JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Parser_00024Builder_build
-  (JNIEnv *, jclass, jobject);
+  (JNIEnv *, jclass, jobject, jlong);
 
 #ifdef __cplusplus
 }

--- a/src/main/java/ch/usi/si/seart/treesitter/Parser.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Parser.java
@@ -84,6 +84,8 @@ public class Parser extends External {
 
         Language language = null;
 
+        long timeout = 0L;
+
         /**
          * Sets the programming language intended for parsing.
          *
@@ -101,6 +103,62 @@ public class Parser extends External {
         }
 
         /**
+         * Set the maximum duration that parsing should be allowed to take.
+         * If parsing time exceeds this value, an exception is thrown.
+         * The duration is rounded down to zero if it does not exceed one microsecond.
+         * Timeouts are considered disabled when the value is zero.
+         *
+         * @param duration the timeout duration
+         * @return this builder
+         * @throws NullPointerException if the duration is {@code null}
+         * @since 1.8.0
+         */
+        public Builder timeout(@NotNull Duration duration) {
+            Objects.requireNonNull(duration, NULL_DURATION);
+            if (duration.isZero()) return this;
+            long micros = duration.toMillis() * TimeUnit.MILLISECONDS.toMicros(1);
+            return timeout(micros);
+        }
+
+        /**
+         * Set the maximum duration that parsing should be allowed to take.
+         * If parsing time exceeds this value, an exception is thrown.
+         * The duration is rounded down to zero if it does not exceed one microsecond.
+         * Timeouts are considered disabled when the value is zero.
+         *
+         * @param timeout the timeout duration amount
+         * @param timeUnit the duration time unit
+         * @return this builder
+         * @throws NullPointerException if the time unit is {@code null}
+         * @throws IllegalArgumentException if the timeout value is negative
+         * @since 1.8.0
+         */
+        public Builder timeout(long timeout, @NotNull TimeUnit timeUnit) {
+            if (timeout == 0) return this;
+            if (timeout < 0) throw new IllegalArgumentException(NEGATIVE_TIMEOUT);
+            Objects.requireNonNull(timeUnit, NULL_TIME_UNIT);
+            long micros = timeUnit.toMicros(timeout);
+            return timeout(micros);
+        }
+
+        /**
+         * Set the maximum duration in microseconds that parsing should be allowed to take.
+         * If parsing time exceeds this value, an exception is thrown.
+         * Timeouts are considered disabled when the value is zero.
+         *
+         * @param timeout the timeout in microseconds
+         * @return this builder
+         * @throws IllegalArgumentException if the timeout value is negative
+         * @since 1.8.0
+         */
+        public Builder timeout(long timeout) {
+            if (timeout == 0) return this;
+            if (timeout < 0) throw new IllegalArgumentException(NEGATIVE_TIMEOUT);
+            this.timeout = timeout;
+            return this;
+        }
+
+        /**
          * Builds and returns a new Parser instance with the configured language.
          *
          * @return A new parser instance
@@ -109,10 +167,10 @@ public class Parser extends External {
          */
         public Parser build() {
             Objects.requireNonNull(language, NULL_LANGUAGE);
-            return build(language);
+            return build(language, timeout);
         }
 
-        private static native Parser build(Language language);
+        private static native Parser build(Language language, long timeout);
     }
 
     /**

--- a/src/main/java/ch/usi/si/seart/treesitter/Parser.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Parser.java
@@ -168,7 +168,7 @@ public class Parser extends External {
     public native long getTimeout();
 
     /**
-     * Set the maximum duration that parsing should be allowed to take before halting.
+     * Set the maximum duration that parsing should be allowed to take.
      * If parsing takes longer than this, an exception is thrown.
      * Note that the supplied duration will be rounded down
      * to 0 if the duration is expressed in nanoseconds.
@@ -184,7 +184,7 @@ public class Parser extends External {
     }
 
     /**
-     * Set the maximum duration that parsing should be allowed to take before halting.
+     * Set the maximum duration that parsing should be allowed to take.
      * If parsing takes longer than this, an exception is thrown.
      * Note that the supplied duration will be rounded down
      * to 0 if the duration is expressed in nanoseconds.
@@ -203,8 +203,7 @@ public class Parser extends External {
     }
 
     /**
-     * Set the maximum duration in microseconds that
-     * parsing should be allowed to take before halting.
+     * Set the maximum duration in microseconds that parsing should be allowed to take.
      * If parsing takes longer than this, an exception is thrown.
      *
      * @param timeout the timeout in microseconds

--- a/src/main/java/ch/usi/si/seart/treesitter/Parser.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Parser.java
@@ -78,6 +78,16 @@ public class Parser extends External {
         return new Builder();
     }
 
+    /**
+     * Obtain a new builder initialized with the current Parser settings.
+     *
+     * @return a new parser builder
+     * @since 1.8.0
+     */
+    public Builder toBuilder() {
+        return builder().language(getLanguage()).timeout(getTimeout());
+    }
+
     @FieldDefaults(level = AccessLevel.PRIVATE)
     @NoArgsConstructor(access = AccessLevel.PRIVATE)
     public static class Builder {

--- a/src/main/java/ch/usi/si/seart/treesitter/Parser.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Parser.java
@@ -170,8 +170,8 @@ public class Parser extends External {
     /**
      * Set the maximum duration that parsing should be allowed to take.
      * If parsing takes longer than this, an exception is thrown.
-     * Note that the supplied duration will be rounded down
-     * to 0 if the duration is expressed in nanoseconds.
+     * The duration is rounded down to zero if it does not exceed one microsecond.
+     * Timeouts are considered disabled when the value is zero.
      *
      * @param duration the timeout duration
      * @throws NullPointerException if the duration is {@code null}
@@ -186,8 +186,8 @@ public class Parser extends External {
     /**
      * Set the maximum duration that parsing should be allowed to take.
      * If parsing takes longer than this, an exception is thrown.
-     * Note that the supplied duration will be rounded down
-     * to 0 if the duration is expressed in nanoseconds.
+     * The duration is rounded down to zero if it does not exceed one microsecond.
+     * Timeouts are considered disabled when the value is zero.
      *
      * @param timeout the timeout duration amount
      * @param timeUnit the duration time unit
@@ -205,6 +205,7 @@ public class Parser extends External {
     /**
      * Set the maximum duration in microseconds that parsing should be allowed to take.
      * If parsing takes longer than this, an exception is thrown.
+     * Timeouts are considered disabled when the value is zero.
      *
      * @param timeout the timeout in microseconds
      * @throws IllegalArgumentException if the timeout value is negative

--- a/src/main/java/ch/usi/si/seart/treesitter/Parser.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Parser.java
@@ -36,6 +36,11 @@ public class Parser extends External {
 
     private static final Charset CHARSET = StandardCharsets.UTF_16LE;
 
+    private static final String NULL_LANGUAGE = "Language must not be null!";
+    private static final String NULL_DURATION = "Duration must not be null!";
+    private static final String NULL_TIME_UNIT = "Time unit must not be null!";
+    private static final String NEGATIVE_TIMEOUT = "Timeout must not be negative!";
+
     @SuppressWarnings("unused")
     Parser(long pointer, @NotNull Language language) {
         super(pointer);
@@ -103,7 +108,7 @@ public class Parser extends External {
          * @throws IncompatibleLanguageException if the language can not be set
          */
         public Parser build() {
-            Objects.requireNonNull(language, "Language must not be null!");
+            Objects.requireNonNull(language, NULL_LANGUAGE);
             return build(language);
         }
 
@@ -173,7 +178,7 @@ public class Parser extends External {
      * @since 1.1.0
      */
     public void setTimeout(@NotNull Duration duration) {
-        Objects.requireNonNull(duration, "Duration must not be null!");
+        Objects.requireNonNull(duration, NULL_DURATION);
         long micros = duration.toMillis() * TimeUnit.MILLISECONDS.toMicros(1);
         setTimeout(micros);
     }
@@ -191,9 +196,8 @@ public class Parser extends External {
      * @since 1.1.0
      */
     public void setTimeout(long timeout, @NotNull TimeUnit timeUnit) {
-        if (timeout < 0)
-            throw new IllegalArgumentException("Timeout can not be negative!");
-        Objects.requireNonNull(timeUnit, "Time unit must not be null!");
+        if (timeout < 0) throw new IllegalArgumentException(NEGATIVE_TIMEOUT);
+        Objects.requireNonNull(timeUnit, NULL_TIME_UNIT);
         long micros = timeUnit.toMicros(timeout);
         setTimeout(micros);
     }

--- a/src/main/java/ch/usi/si/seart/treesitter/Parser.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Parser.java
@@ -169,7 +169,7 @@ public class Parser extends External {
 
     /**
      * Set the maximum duration that parsing should be allowed to take.
-     * If parsing takes longer than this, an exception is thrown.
+     * If parsing time exceeds this value, an exception is thrown.
      * The duration is rounded down to zero if it does not exceed one microsecond.
      * Timeouts are considered disabled when the value is zero.
      *
@@ -185,7 +185,7 @@ public class Parser extends External {
 
     /**
      * Set the maximum duration that parsing should be allowed to take.
-     * If parsing takes longer than this, an exception is thrown.
+     * If parsing time exceeds this value, an exception is thrown.
      * The duration is rounded down to zero if it does not exceed one microsecond.
      * Timeouts are considered disabled when the value is zero.
      *
@@ -204,7 +204,7 @@ public class Parser extends External {
 
     /**
      * Set the maximum duration in microseconds that parsing should be allowed to take.
-     * If parsing takes longer than this, an exception is thrown.
+     * If parsing time exceeds this value, an exception is thrown.
      * Timeouts are considered disabled when the value is zero.
      *
      * @param timeout the timeout in microseconds

--- a/src/test/java/ch/usi/si/seart/treesitter/ParserTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/ParserTest.java
@@ -122,6 +122,18 @@ class ParserTest extends TestBase {
         Assertions.assertEquals(duration.toMillis() * 1000, parser.getTimeout());
     }
 
+    @Test
+    void testToBuilder() {
+        Parser.Builder builder = parser.toBuilder();
+        @Cleanup Parser other = builder.language(Language.JAVA)
+                .timeout(Duration.ofSeconds(1))
+                .build();
+        Assertions.assertFalse(other.isNull());
+        Assertions.assertNotEquals(parser, other);
+        Assertions.assertNotEquals(parser.getTimeout(), other.getTimeout());
+        Assertions.assertNotEquals(parser.getLanguage(), other.getLanguage());
+    }
+
     private static class ConstructorExceptionProvider implements ArgumentsProvider {
 
         @Override

--- a/src/test/java/ch/usi/si/seart/treesitter/ParserTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/ParserTest.java
@@ -111,6 +111,17 @@ class ParserTest extends TestBase {
         Assertions.assertEquals(0, parser.getTimeout());
     }
 
+    @Test
+    void testBuilder() {
+        Duration duration = Duration.ofSeconds(3);
+        @Cleanup Parser parser = Parser.builder()
+                .language(Language.JAVA)
+                .timeout(duration)
+                .build();
+        Assertions.assertFalse(parser.isNull());
+        Assertions.assertEquals(duration.toMillis() * 1000, parser.getTimeout());
+    }
+
     private static class ConstructorExceptionProvider implements ArgumentsProvider {
 
         @Override
@@ -155,6 +166,7 @@ class ParserTest extends TestBase {
     @ArgumentsSource(SetTimeoutExceptionProvider.class)
     void testSetTimeoutThrows(Class<Throwable> throwableType, Long timeout) {
         Assertions.assertThrows(throwableType, () -> parser.setTimeout(timeout));
+        Assertions.assertThrows(throwableType, () -> Parser.builder().timeout(timeout));
     }
 
     private static class SetTimeoutWitTimeUnitExceptionProvider implements ArgumentsProvider {
@@ -172,5 +184,6 @@ class ParserTest extends TestBase {
     @ArgumentsSource(SetTimeoutWitTimeUnitExceptionProvider.class)
     void testSetTimeoutThrows(Class<Throwable> throwableType, Long timeout, TimeUnit timeUnit) {
         Assertions.assertThrows(throwableType, () -> parser.setTimeout(timeout, timeUnit));
+        Assertions.assertThrows(throwableType, () -> Parser.builder().timeout(timeout, timeUnit));
     }
 }

--- a/src/test/java/ch/usi/si/seart/treesitter/ParserTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/ParserTest.java
@@ -100,6 +100,11 @@ class ParserTest extends TestBase {
         parser.setTimeout(duration);
         Assertions.assertEquals(duration.toMillis() * 1000, parser.getTimeout());
         Assertions.assertFalse(parser.parse(path).isNull());
+    }
+
+    @Test
+    void testSetTimeoutNanoseconds() {
+        Assertions.assertEquals(0, parser.getTimeout());
         parser.setTimeout(Duration.ofNanos(500));
         Assertions.assertEquals(0, parser.getTimeout());
         parser.setTimeout(500, TimeUnit.NANOSECONDS);


### PR DESCRIPTION
Two new additions have been made to the API:
- Methods for directly specifying the `Parser` timeout have been added
- Added a `toBuilder` method which acts as a means of duplicating `Parser` instances