### PR TITLE
Removing some redundant `toString`  implementations

### DIFF
--- a/src/main/java/ch/usi/si/seart/treesitter/Node.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Node.java
@@ -336,7 +336,7 @@ public class Node implements Iterable<Node> {
     @Override
     @Generated
     public String toString() {
-        return String.format("Node(id: %d, tree: %d)", id, tree.pointer);
+        return String.format("Node(id: %d, tree: %s)", id, tree);
     }
 
     /**

--- a/src/main/java/ch/usi/si/seart/treesitter/Parser.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Parser.java
@@ -278,6 +278,6 @@ public class Parser extends External {
     @Override
     @Generated
     public String toString() {
-        return String.format("Parser(id: %d, language: %s)", pointer, language);
+        return String.format("Parser(language: %s)", language);
     }
 }

--- a/src/main/java/ch/usi/si/seart/treesitter/Parser.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Parser.java
@@ -3,7 +3,6 @@ package ch.usi.si.seart.treesitter;
 import ch.usi.si.seart.treesitter.exception.parser.IncompatibleLanguageException;
 import ch.usi.si.seart.treesitter.exception.parser.ParsingException;
 import lombok.AccessLevel;
-import lombok.Generated;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.FieldDefaults;
@@ -274,10 +273,4 @@ public class Parser extends External {
     }
 
     private native Tree parse(String source, byte[] bytes, int length, Tree oldTree);
-
-    @Override
-    @Generated
-    public String toString() {
-        return String.format("Parser(language: %s)", language);
-    }
 }

--- a/src/main/java/ch/usi/si/seart/treesitter/Tree.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Tree.java
@@ -1,7 +1,6 @@
 package ch.usi.si.seart.treesitter;
 
 import lombok.AccessLevel;
-import lombok.Generated;
 import lombok.Getter;
 import lombok.experimental.FieldDefaults;
 import org.jetbrains.annotations.NotNull;
@@ -65,12 +64,6 @@ public class Tree extends External implements Iterable<Node>, Cloneable {
      */
     @Override
     public native Tree clone();
-
-    @Override
-    @Generated
-    public String toString() {
-        return String.format("Tree(language: %s)", language);
-    }
 
     String getSource(int startByte, int endByte) {
         byte[] bytes = source.getBytes(CHARSET);

--- a/src/main/java/ch/usi/si/seart/treesitter/Tree.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Tree.java
@@ -69,7 +69,7 @@ public class Tree extends External implements Iterable<Node>, Cloneable {
     @Override
     @Generated
     public String toString() {
-        return String.format("Tree(id: %d, language: %s)", pointer, language);
+        return String.format("Tree(language: %s)", language);
     }
 
     String getSource(int startByte, int endByte) {

--- a/src/main/java/ch/usi/si/seart/treesitter/TreeCursor.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/TreeCursor.java
@@ -1,7 +1,6 @@
 package ch.usi.si.seart.treesitter;
 
 import lombok.AccessLevel;
-import lombok.Generated;
 import lombok.experimental.FieldDefaults;
 import org.jetbrains.annotations.NotNull;
 
@@ -136,12 +135,6 @@ public class TreeCursor extends External implements Cloneable {
                 if (!gotoParent()) return;
             } while (!gotoNextSibling());
         }
-    }
-
-    @Override
-    @Generated
-    public String toString() {
-        return String.format("TreeCursor(id: %d, tree: %d)", id, tree.pointer);
     }
 
     /**


### PR DESCRIPTION
This affects:
- `Tree`
- `TreeCursor`
- `Parser`

`Node` has also been changed to not rely on `Tree` pointers.