### PR TITLE
Fixing rare cases of segmentation faults in `OffsetTreeCursor$OffsetNode`

### DIFF
--- a/src/main/java/ch/usi/si/seart/treesitter/OffsetTreeCursor.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/OffsetTreeCursor.java
@@ -268,6 +268,29 @@ public class OffsetTreeCursor extends TreeCursor {
         public QueryCursor walk(@NotNull Query query) {
             throw new UnsupportedOperationException(UOE_MESSAGE_3);
         }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) return true;
+            if (obj == null || getClass() != obj.getClass()) return false;
+            OffsetNode other = (OffsetNode) obj;
+            return node.equals(other.node);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(node, offset);
+        }
+
+        @Override
+        public String toString() {
+            String original = node.toString();
+            String data = original.substring(5, original.length() - 1);
+            return String.format(
+                    "OffsetNode(%s, row: %d, column: %d)",
+                    data, offset.getRow(), offset.getColumn()
+            );
+        }
     }
 
     @Override

--- a/src/main/java/ch/usi/si/seart/treesitter/OffsetTreeCursor.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/OffsetTreeCursor.java
@@ -117,6 +117,11 @@ public class OffsetTreeCursor extends TreeCursor {
         }
 
         @Override
+        public int getChildCount() {
+            return node.getChildCount();
+        }
+
+        @Override
         public List<Node> getChildren() {
             return node.getChildren().stream()
                     .map(OffsetNode::new)
@@ -149,6 +154,11 @@ public class OffsetTreeCursor extends TreeCursor {
         @Override
         public Point getEndPoint() {
             return node.getEndPoint().add(offset);
+        }
+
+        @Override
+        public String getFieldNameForChild(int child) {
+            return node.getFieldNameForChild(child);
         }
 
         @Override
@@ -212,6 +222,41 @@ public class OffsetTreeCursor extends TreeCursor {
         @Override
         public Point getStartPoint() {
             return node.getStartPoint().add(offset);
+        }
+
+        @Override
+        public Symbol getSymbol() {
+            return node.getSymbol();
+        }
+
+        @Override
+        public String getType() {
+            return node.getType();
+        }
+
+        @Override
+        public boolean hasError() {
+            return node.hasError();
+        }
+
+        @Override
+        public boolean isExtra() {
+            return node.isExtra();
+        }
+
+        @Override
+        public boolean isMissing() {
+            return node.isMissing();
+        }
+
+        @Override
+        public boolean isNamed() {
+            return node.isNamed();
+        }
+
+        @Override
+        public boolean isNull() {
+            return node.isNull();
         }
 
         @Override

--- a/src/main/java/ch/usi/si/seart/treesitter/OffsetTreeCursor.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/OffsetTreeCursor.java
@@ -289,7 +289,9 @@ public class OffsetTreeCursor extends TreeCursor {
         @Override
         public String toString() {
             String original = node.toString();
-            String data = original.substring(5, original.length() - 1);
+            int lower = 5;
+            int upper = original.length() - 1;
+            String data = original.substring(lower, upper);
             return String.format(
                     "OffsetNode(%s, row: %d, column: %d)",
                     data, offset.getRow(), offset.getColumn()

--- a/src/main/java/ch/usi/si/seart/treesitter/OffsetTreeCursor.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/OffsetTreeCursor.java
@@ -289,7 +289,7 @@ public class OffsetTreeCursor extends TreeCursor {
         @Override
         public String toString() {
             String original = node.toString();
-            int lower = 5;
+            int lower = Node.class.getSimpleName().length() + 1;
             int upper = original.length() - 1;
             String data = original.substring(lower, upper);
             return String.format(

--- a/src/main/java/ch/usi/si/seart/treesitter/OffsetTreeCursor.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/OffsetTreeCursor.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.experimental.FieldDefaults;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
@@ -125,7 +126,10 @@ public class OffsetTreeCursor extends TreeCursor {
         public List<Node> getChildren() {
             return node.getChildren().stream()
                     .map(OffsetNode::new)
-                    .collect(Collectors.toList());
+                    .collect(Collectors.collectingAndThen(
+                            Collectors.toList(),
+                            Collections::unmodifiableList
+                    ));
         }
 
         @Override


### PR DESCRIPTION
Invocations to native parent methods were not delegated to the wrapped child, causing segmentation faults.