### PR TITLE
Fixing memory leak in `TreeCursor` cleanup

### DIFF
--- a/lib/ch_usi_si_seart_treesitter_TreeCursor.cc
+++ b/lib/ch_usi_si_seart_treesitter_TreeCursor.cc
@@ -7,7 +7,7 @@
 JNIEXPORT void JNICALL Java_ch_usi_si_seart_treesitter_TreeCursor_delete(
   JNIEnv* env, jobject thisObject) {
   TSTreeCursor* treeCursor = (TSTreeCursor*)__getPointer(env, thisObject);
-  delete treeCursor;
+  ts_tree_cursor_delete(treeCursor);
   __clearPointer(env, thisObject);
 }
 


### PR DESCRIPTION
The faulty cleanup code was there from the beginning, brought over from the original source code. Not sure how this went unchecked for so long... First reported and patched upstream in https://github.com/serenadeai/java-tree-sitter/pull/18. 