### PR TITLE
Lower Java version requirement from 11 to 8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,11 @@ LABEL maintainer="Ozren Dabić (dabico@usi.ch)"
 
 ENV IMAGE_NAME="seart-group/java-tree-sitter" \
     IMAGE_REPO_URL="https://github.com/${IMAGE_NAME}/" \
-    JAVA_HOME="/usr/lib/jvm/java-11-openjdk"
+    JAVA_HOME="/usr/lib/jvm/java-8-openjdk"
 
 RUN apk update && \
     apk add --no-cache \
-            openjdk11 \
+            openjdk8 \
             python3 \
             py3-distutils-extra \
             make \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ ENV IMAGE_NAME="seart-group/java-tree-sitter" \
     JAVA_HOME="/usr/lib/jvm/java-11-openjdk"
 
 RUN apk update && \
-    apk add openjdk11 \
+    apk add --no-cache \
+            openjdk11 \
             python3 \
             py3-distutils-extra \
             make \

--- a/lib/ch_usi_si_seart_treesitter.cc
+++ b/lib/ch_usi_si_seart_treesitter.cc
@@ -1,7 +1,7 @@
 #include "ch_usi_si_seart_treesitter.h"
 #include <jni.h>
 
-static jint JNI_VERSION = JNI_VERSION_10;
+static jint JNI_VERSION = JNI_VERSION_1_8;
 
 jclass _stringClass;
 

--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.11.0</version>
         <configuration>
-          <release>${java.version}</release>
+          <source>${java.version}</source>
+          <target>${java.version}</target>
           <compilerArgs>
             <arg>-h</arg>
             <arg>${project.basedir}/lib</arg>

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <java.version>11</java.version>
+    <java.version>8</java.version>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <java.version>8</java.version>
+    <java.version>1.8</java.version>
   </properties>
 
   <dependencyManagement>
@@ -145,7 +145,7 @@
                   <family>unix</family>
                 </requireOS>
                 <requireJavaVersion>
-                  <version>1.${java.version}</version>
+                  <version>${java.version}</version>
                 </requireJavaVersion>
                 <requireMavenVersion>
                   <version>3.0.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>10.12.4</version>
+            <version>9.3</version>
           </dependency>
         </dependencies>
         <executions>

--- a/src/main/java/ch/usi/si/seart/treesitter/CleanerThread.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/CleanerThread.java
@@ -1,0 +1,146 @@
+package ch.usi.si.seart.treesitter;
+
+import lombok.AccessLevel;
+import lombok.experimental.FieldDefaults;
+import lombok.experimental.NonFinal;
+
+import java.lang.ref.PhantomReference;
+import java.lang.ref.ReferenceQueue;
+import java.util.Objects;
+
+/**
+ * Java 8 implementation of {@link java.lang.ref.Cleaner Cleaner}.
+ * Implementation is heavily inspired by said Java 9 feature,
+ * as well as the {@link sun.misc.Cleaner Cleaner} from <em>sun</em>.
+ * One minor difference with respect to these implementations is that
+ * {@code CleanerThread} can be killed and respawned as needed.
+ * Intended only for internal usage.
+ *
+ * @author Juan Lopes
+ * @author Ozren Dabić
+ * @see <a href="https://codereview.stackexchange.com/q/278276">Code Review Tread</a>
+ * @since 1.8
+ */
+@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+class CleanerThread {
+
+    interface Cleaner {
+        void clean();
+    }
+
+    interface Action {
+        void run(boolean leak);
+    }
+
+    ReferenceQueue<Object> queue = new ReferenceQueue<>();
+
+    long keepAlive;
+
+    @NonFinal
+    boolean threadRunning = false;
+
+    @NonFinal
+    PhantomNode first;
+
+    CleanerThread(long keepAlive) {
+        this.keepAlive = keepAlive;
+    }
+
+    public Cleaner register(Object obj, Action action) {
+        PhantomNode node = new PhantomNode(obj, action);
+        add(node);
+        return node;
+    }
+
+    private synchronized boolean isEmpty() {
+        if (first == null) {
+            threadRunning = false;
+            return true;
+        }
+        return false;
+    }
+
+    private synchronized void add(PhantomNode node) {
+        if (first != null) {
+            node.nextNode = first;
+            first.prevNode = node;
+        }
+        first = node;
+
+        if (!threadRunning) {
+            threadRunning = true;
+            startThread();
+        }
+    }
+
+    private void startThread() {
+        Thread thread = new Thread(() -> {
+            while (true) {
+                try {
+                    PhantomNode ref = (PhantomNode) queue.remove(keepAlive);
+                    if (ref != null) {
+                        ref.cleanInternal(true);
+                    } else if (isEmpty()) {
+                        break;
+                    }
+                } catch (Throwable ignored) {
+                    // ignore exceptions from the cleanup action
+                    // (including interruption of cleanup thread)
+                }
+            }
+        }, "tree-sitter-cleaner");
+        thread.setDaemon(true);
+        thread.start();
+    }
+
+    private synchronized boolean remove(PhantomNode node) {
+        // If already removed, do nothing
+        if (node.nextNode == node)
+            return false;
+
+        // Update list
+        if (first == node)
+            first = node.nextNode;
+        if (node.nextNode != null)
+            node.nextNode.prevNode = node.prevNode;
+        if (node.prevNode != null)
+            node.prevNode.nextNode = node.nextNode;
+
+        // Indicate removal by pointing the cleaner to itself
+        node.nextNode = node;
+        node.prevNode = node;
+
+        return true;
+    }
+
+    @FieldDefaults(level = AccessLevel.PRIVATE)
+    private class PhantomNode extends PhantomReference<Object> implements Cleaner {
+
+        final Action action;
+
+        PhantomNode prevNode;
+        PhantomNode nextNode;
+
+        PhantomNode(Object referent, Action action) {
+            super(referent, queue);
+            this.action = action;
+            Objects.requireNonNull(referent, "Referent must not be null!");
+        }
+
+        @Override
+        public void clean() {
+            cleanInternal(false);
+        }
+
+        private void cleanInternal(boolean leak) {
+            if (!remove(this))
+                return;
+            try {
+                action.run(leak);
+            } catch (Throwable e) {
+                // Should not happen if cleaners are well-behaved
+                e.printStackTrace();
+            }
+        }
+    }
+}

--- a/src/main/java/ch/usi/si/seart/treesitter/Language.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Language.java
@@ -484,7 +484,10 @@ public enum Language {
                     Map.Entry::getKey,
                     Collectors.mapping(
                             Map.Entry::getValue,
-                            Collectors.toUnmodifiableList()
+                            Collectors.collectingAndThen(
+                                    Collectors.toList(),
+                                    Collections::unmodifiableList
+                            )
                     )
             ));
 

--- a/src/main/java/ch/usi/si/seart/treesitter/Language.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Language.java
@@ -10,6 +10,7 @@ import org.jetbrains.annotations.TestOnly;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.AbstractMap;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -480,7 +481,9 @@ public enum Language {
     private static final long INVALID = 0L;
 
     private static final Map<String, List<Language>> EXTENSION_LOOKUP = Stream.of(Language.values())
-            .flatMap(language -> language.getExtensions().stream().map(extension -> Map.entry(extension, language)))
+            .flatMap(language -> language.getExtensions().stream().map(
+                    extension -> new AbstractMap.SimpleEntry<>(extension, language)
+            ))
             .collect(Collectors.groupingBy(
                     Map.Entry::getKey,
                     Collectors.mapping(

--- a/src/main/java/ch/usi/si/seart/treesitter/Language.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Language.java
@@ -513,7 +513,10 @@ public enum Language {
         this.totalFields = totalFields;
         this.symbols = IntStream.range(0, totalSymbols)
                 .mapToObj(symbolId -> symbol(id, symbolId))
-                .collect(Collectors.toList());
+                .collect(Collectors.collectingAndThen(
+                        Collectors.toList(),
+                        Collections::unmodifiableList
+                ));
         this.extensions = extensions;
     }
 

--- a/src/main/java/ch/usi/si/seart/treesitter/Language.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Language.java
@@ -10,6 +10,7 @@ import org.jetbrains.annotations.TestOnly;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -500,7 +501,7 @@ public enum Language {
     }
 
     Language(long id, String... extensions) {
-        this(id, version(id), fields(id), symbols(id), List.of(extensions));
+        this(id, version(id), fields(id), symbols(id), Collections.unmodifiableList(Arrays.asList(extensions)));
     }
 
     Language(long id, int version, int totalFields, int totalSymbols, List<String> extensions) {

--- a/src/main/java/ch/usi/si/seart/treesitter/LibraryLoader.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/LibraryLoader.java
@@ -60,7 +60,7 @@ public class LibraryLoader {
                     File temporary = new File(tmpdir, systemResource.name);
                     temporary.deleteOnExit();
                     @Cleanup OutputStream output = new FileOutputStream(temporary, false);
-                    input.transferTo(output);
+                    copy(input, output);
                     return temporary.getPath();
                 } catch (IOException cause) {
                     throw new TreeSitterException(cause);
@@ -81,6 +81,15 @@ public class LibraryLoader {
             throw new TreeSitterException(
                     "The tree-sitter library was not compiled for this platform: " + platform
             );
+        }
+    }
+
+    private static void copy(InputStream inputStream, OutputStream outputStream) throws IOException {
+        int size = 8192;
+        byte[] buffer = new byte[size];
+        int read;
+        while ((read = inputStream.read(buffer, 0, size)) >= 0) {
+            outputStream.write(buffer, 0, read);
         }
     }
 }

--- a/src/main/java/ch/usi/si/seart/treesitter/LibraryLoader.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/LibraryLoader.java
@@ -84,11 +84,12 @@ public class LibraryLoader {
         }
     }
 
+    private static final int COPY_BUFFER_SIZE = 8192;
+
     private static void copy(InputStream inputStream, OutputStream outputStream) throws IOException {
-        int size = 8192;
-        byte[] buffer = new byte[size];
+        byte[] buffer = new byte[COPY_BUFFER_SIZE];
         int read;
-        while ((read = inputStream.read(buffer, 0, size)) >= 0) {
+        while ((read = inputStream.read(buffer, 0, COPY_BUFFER_SIZE)) >= 0) {
             outputStream.write(buffer, 0, read);
         }
     }

--- a/src/main/java/ch/usi/si/seart/treesitter/Node.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Node.java
@@ -347,7 +347,7 @@ public class Node implements Iterable<Node> {
      */
     @Override
     public @NotNull Iterator<Node> iterator() {
-        return new Iterator<>() {
+        return new Iterator<Node>() {
 
             private final Deque<Node> stack = new ArrayDeque<>(Collections.singletonList(Node.this));
 

--- a/src/main/java/ch/usi/si/seart/treesitter/Node.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Node.java
@@ -7,6 +7,8 @@ import lombok.experimental.FieldDefaults;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Deque;
 import java.util.Iterator;
 import java.util.List;
@@ -66,8 +68,9 @@ public class Node implements Iterable<Node> {
      * @return A list of the node's children
      */
     public List<Node> getChildren() {
-        Node[] children = Node.getChildren(this);
-        return List.of(children);
+        Node[] array = Node.getChildren(this);
+        List<Node> list = Arrays.asList(array);
+        return Collections.unmodifiableList(list);
     }
 
     private static native Node[] getChildren(Node node);
@@ -346,7 +349,7 @@ public class Node implements Iterable<Node> {
     public @NotNull Iterator<Node> iterator() {
         return new Iterator<>() {
 
-            private final Deque<Node> stack = new ArrayDeque<>(List.of(Node.this));
+            private final Deque<Node> stack = new ArrayDeque<>(Collections.singletonList(Node.this));
 
             @Override
             public boolean hasNext() {

--- a/src/main/java/ch/usi/si/seart/treesitter/Node.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Node.java
@@ -84,7 +84,7 @@ public class Node implements Iterable<Node> {
      * @deprecated Use {@link #getDescendant(int, int)} instead
      * @return The smallest node within this node that spans the given range of bytes
      */
-    @Deprecated(since = "1.6.0", forRemoval = true)
+    @Deprecated
     public Node getDescendantForByteRange(int startByte, int endByte) {
         return getDescendant(startByte, endByte);
     }

--- a/src/main/java/ch/usi/si/seart/treesitter/Parser.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Parser.java
@@ -45,7 +45,7 @@ public class Parser extends External {
     /**
      * @deprecated Use {@link Parser#getFor(Language)} or {@link Parser#builder()} instead
      */
-    @Deprecated(since = "1.7.0", forRemoval = true)
+    @Deprecated
     public Parser(@NotNull Language language) {
         throw new UnsupportedOperationException(
                 "This constructor should no longer be used"

--- a/src/main/java/ch/usi/si/seart/treesitter/Parser.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Parser.java
@@ -247,7 +247,8 @@ public class Parser extends External {
      */
     public Tree parse(@NotNull Path path) throws ParsingException {
         try {
-            String source = Files.readString(path);
+            byte[] bytes = Files.readAllBytes(path);
+            String source = new String(bytes);
             return parse(source);
         } catch (IOException ex) {
             throw new ParsingException(ex);
@@ -266,7 +267,8 @@ public class Parser extends External {
      */
     public Tree parse(@NotNull Path path, @NotNull Tree oldTree) throws ParsingException {
         try {
-            String source = Files.readString(path);
+            byte[] bytes = Files.readAllBytes(path);
+            String source = new String(bytes);
             return parse(source, oldTree);
         } catch (IOException ex) {
             throw new ParsingException(ex);

--- a/src/main/java/ch/usi/si/seart/treesitter/Query.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Query.java
@@ -8,6 +8,8 @@ import lombok.NoArgsConstructor;
 import lombok.experimental.FieldDefaults;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -42,9 +44,9 @@ public class Query extends External {
     ) {
         super(pointer);
         this.language = language;
-        this.patterns = List.of(patterns);
-        this.captures = List.of(captures);
-        this.strings = List.of(strings);
+        this.patterns = Collections.unmodifiableList(Arrays.asList(patterns));
+        this.captures = Collections.unmodifiableList(Arrays.asList(captures));
+        this.strings = Collections.unmodifiableList(Arrays.asList(strings));
     }
 
     /**

--- a/src/main/java/ch/usi/si/seart/treesitter/Query.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Query.java
@@ -50,7 +50,7 @@ public class Query extends External {
     /**
      * @deprecated Use {@link Query#getFor(Language, String)} or {@link Query#builder()} instead
      */
-    @Deprecated(since = "1.7.0", forRemoval = true)
+    @Deprecated
     public Query(@NotNull Language language, @NotNull String pattern) {
         throw new UnsupportedOperationException(
                 "This constructor should no longer be used"
@@ -137,7 +137,7 @@ public class Query extends External {
     /**
      * @deprecated Just get dedicated collection, and compute {@link List#size() size()}
      */
-    @Deprecated(since = "1.7.0", forRemoval = true)
+    @Deprecated
     public int countStrings() {
         return strings.size();
     }
@@ -145,7 +145,7 @@ public class Query extends External {
     /**
      * @deprecated Just get dedicated collection, and compute {@link List#size() size()}
      */
-    @Deprecated(since = "1.7.0", forRemoval = true)
+    @Deprecated
     public int countCaptures() {
         return captures.size();
     }
@@ -153,7 +153,7 @@ public class Query extends External {
     /**
      * @deprecated Just get dedicated collection, and compute {@link List#size() size()}
      */
-    @Deprecated(since = "1.7.0", forRemoval = true)
+    @Deprecated
     public int countPatterns() {
         return patterns.size();
     }
@@ -162,7 +162,7 @@ public class Query extends External {
      * @deprecated Should not be used anymore
      * @see QueryMatch
      */
-    @Deprecated(since = "1.7.0", forRemoval = true)
+    @Deprecated
     public String getCaptureName(@NotNull Object ignored) {
         throw new UnsupportedOperationException(
                 "This method should no longer be used"

--- a/src/main/java/ch/usi/si/seart/treesitter/QueryCapture.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/QueryCapture.java
@@ -10,7 +10,7 @@ import lombok.experimental.FieldDefaults;
  * @deprecated Currently obsolete, refrain from further use
  * @see QueryMatch
  */
-@Deprecated(since = "1.7.0", forRemoval = true)
+@Deprecated
 @Getter
 @AllArgsConstructor(access = AccessLevel.PACKAGE)
 @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)

--- a/src/main/java/ch/usi/si/seart/treesitter/QueryCursor.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/QueryCursor.java
@@ -39,7 +39,7 @@ public class QueryCursor extends External implements Iterable<QueryMatch> {
      * @deprecated Use {@link Node#walk(Query)} instead
      * @throws UnsupportedOperationException when called
      */
-    @Deprecated(since = "1.5.0", forRemoval = true)
+    @Deprecated
     public QueryCursor(@NotNull Node node, @NotNull Query query) {
         super();
         throw new UnsupportedOperationException(

--- a/src/main/java/ch/usi/si/seart/treesitter/QueryCursor.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/QueryCursor.java
@@ -70,7 +70,7 @@ public class QueryCursor extends External implements Iterable<QueryMatch> {
     @Override
     public @NotNull Iterator<QueryMatch> iterator() {
         execute();
-        return new Iterator<>() {
+        return new Iterator<QueryMatch>() {
 
             private QueryMatch current = nextMatch();
 

--- a/src/main/java/ch/usi/si/seart/treesitter/QueryMatch.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/QueryMatch.java
@@ -93,7 +93,7 @@ public class QueryMatch {
      * @deprecated Use dedicated {@link QueryMatch#pattern} getter instead
      */
     @Generated
-    @Deprecated(since = "1.7.0", forRemoval = true)
+    @Deprecated
     public int getPatternIndex() {
         return getPattern().getIndex();
     }

--- a/src/main/java/ch/usi/si/seart/treesitter/QueryMatch.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/QueryMatch.java
@@ -10,6 +10,7 @@ import org.apache.commons.collections4.multimap.UnmodifiableMultiValuedMap;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -86,7 +87,10 @@ public class QueryMatch {
                     return name.equals(capture.getName());
                 })
                 .map(Map.Entry::getValue)
-                .collect(Collectors.toUnmodifiableList());
+                .collect(Collectors.collectingAndThen(
+                        Collectors.toList(),
+                        Collections::unmodifiableList
+                ));
     }
 
     /**

--- a/src/main/java/ch/usi/si/seart/treesitter/printer/DotGraphPrinter.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/printer/DotGraphPrinter.java
@@ -40,7 +40,8 @@ public class DotGraphPrinter implements TreePrinter {
         try {
             File file = export();
             Path path = file.toPath();
-            String contents = Files.readString(path);
+            byte[] bytes = Files.readAllBytes(path);
+            String contents = new String(bytes);
             Files.delete(path);
             return contents;
         } catch (IOException ex) {

--- a/src/main/java/ch/usi/si/seart/treesitter/printer/SyntaxTreePrinter.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/printer/SyntaxTreePrinter.java
@@ -4,6 +4,8 @@ import ch.usi.si.seart.treesitter.TreeCursor;
 import ch.usi.si.seart.treesitter.TreeCursorNode;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.function.Consumer;
 
 /**
@@ -35,7 +37,8 @@ public class SyntaxTreePrinter extends IterativeTreePrinter {
         for (;;) {
             TreeCursorNode cursorNode = cursor.getCurrentTreeCursorNode();
             if (cursorNode.isNamed()) {
-                String indent = "  ".repeat(depth);
+                Collection<String> spaces = Collections.nCopies(depth, "  ");
+                String indent = String.join("", spaces);
                 appender.accept(indent);
                 appender.accept(cursorNode.toString());
                 appender.accept("\n");

--- a/src/test/java/ch/usi/si/seart/treesitter/LanguageTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/LanguageTest.java
@@ -9,7 +9,10 @@ import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 
 import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
@@ -23,7 +26,7 @@ class LanguageTest extends TestBase {
 
         @Override
         public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) {
-            Predicate<Language> notInvalid = Predicate.not(Language._INVALID_::equals);
+            Predicate<Language> notInvalid = language -> !Language._INVALID_.equals(language);
             return Stream.of(Language.values())
                     .filter(notInvalid)
                     .map(Arguments::of);
@@ -58,13 +61,15 @@ class LanguageTest extends TestBase {
         @Override
         public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) {
             return Stream.of(
-                    Arguments.of("requirements.txt", List.of()),
-                    Arguments.of("__init__.py", List.of(Language.PYTHON)),
-                    Arguments.of("Main.java", List.of(Language.JAVA)),
-                    Arguments.of("example.h", List.of(
-                            Language.C,
-                            Language.CPP,
-                            Language.OBJECTIVE_C
+                    Arguments.of("requirements.txt", Collections.emptyList()),
+                    Arguments.of("__init__.py", Collections.singletonList(Language.PYTHON)),
+                    Arguments.of("Main.java", Collections.singletonList(Language.JAVA)),
+                    Arguments.of("example.h", Collections.unmodifiableList(
+                            Arrays.asList(
+                                    Language.C,
+                                    Language.CPP,
+                                    Language.OBJECTIVE_C
+                            )
                     ))
             );
         }
@@ -73,7 +78,7 @@ class LanguageTest extends TestBase {
     @ParameterizedTest(name = "[{index}] {0}")
     @ArgumentsSource(AssociatedWithProvider.class)
     void testAssociatedWith(String name, List<Language> expected) {
-        Path path = Path.of(tmp.toString(), name);
+        Path path = Paths.get(tmp.toString(), name);
         Collection<Language> actual = Language.associatedWith(path);
         Assertions.assertNotNull(actual);
         Assertions.assertEquals(expected.size(), actual.size());

--- a/src/test/java/ch/usi/si/seart/treesitter/NodeTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/NodeTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.NullSource;
 
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -90,7 +91,7 @@ class NodeTest extends TestBase {
         for (int i = 0; i < count; i++) {
             Assertions.assertEquals(function.getChild(i), children.get(i));
         }
-        Assertions.assertEquals(empty.getChildren(), List.of());
+        Assertions.assertEquals(Collections.emptyList(), empty.getChildren());
     }
 
     @Test

--- a/src/test/java/ch/usi/si/seart/treesitter/ParserTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/ParserTest.java
@@ -14,10 +14,12 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 
+import java.io.FileWriter;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
@@ -34,9 +36,10 @@ class ParserTest extends TestBase {
 
     @BeforeAll
     static void beforeAll() throws IOException {
-        tmpFile = Files.createFile(tmp.resolve("print.py"));
-        Files.writeString(tmpFile, source);
         parser = Parser.getFor(Language.PYTHON);
+        tmpFile = Files.createFile(tmp.resolve("print.py"));
+        @Cleanup FileWriter fileWriter = new FileWriter(tmpFile.toFile());
+        fileWriter.write(source);
     }
 
     @AfterAll
@@ -90,7 +93,7 @@ class ParserTest extends TestBase {
         Assertions.assertEquals(0, parser.getTimeout());
         parser.setTimeout(10);
         Assertions.assertEquals(10, parser.getTimeout());
-        Path path = Path.of(getClass().getClassLoader().getResource("deep_string_concat").toURI());
+        Path path = Paths.get(getClass().getClassLoader().getResource("deep_string_concat").toURI());
         Assertions.assertThrows(ParsingException.class, () -> parser.parse(path));
         TimeUnit unit = TimeUnit.SECONDS;
         parser.setTimeout(1, unit);

--- a/src/test/java/ch/usi/si/seart/treesitter/PointTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/PointTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -24,7 +25,7 @@ class PointTest extends TestBase {
 
     @Test
     void testCompareTo() {
-        List<Point> sorted = List.of(_0_0_, _0_1_, _1_0_, _1_1_);
+        List<Point> sorted = Collections.unmodifiableList(Arrays.asList(_0_0_, _0_1_, _1_0_, _1_1_));
         ArrayList<Point> unsorted = new ArrayList<>(sorted);
         Collections.shuffle(unsorted);
         Collections.sort(unsorted);

--- a/src/test/java/ch/usi/si/seart/treesitter/printer/DotGraphPrinterTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/printer/DotGraphPrinterTest.java
@@ -13,6 +13,8 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 class DotGraphPrinterTest extends TestBase {
 
@@ -43,7 +45,8 @@ class DotGraphPrinterTest extends TestBase {
         TreePrinter printer = new DotGraphPrinter(tree);
         File file = printer.export();
         Path path = file.toPath();
-        String actual = Files.readString(path);
+        byte[] bytes = Files.readAllBytes(path);
+        String actual = new String(bytes);
         Files.delete(file.toPath());
         assertion(actual);
     }
@@ -54,7 +57,9 @@ class DotGraphPrinterTest extends TestBase {
     }
 
     private void assertion(String result) {
-        Assertions.assertEquals(594, result.lines().count());
+        Pattern pattern = Pattern.compile("\\R");
+        Stream<String> lines = pattern.splitAsStream(result);
+        Assertions.assertEquals(594, lines.count());
         Assertions.assertTrue(result.startsWith("digraph tree {"));
         Assertions.assertTrue(result.endsWith("}\n"));
     }

--- a/src/test/java/ch/usi/si/seart/treesitter/printer/PrinterTestBase.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/printer/PrinterTestBase.java
@@ -40,7 +40,8 @@ public abstract class PrinterTestBase extends TestBase {
         String expected = getExpected();
         File file = printer.export();
         Path path = file.toPath();
-        String actual = Files.readString(path);
+        byte[] bytes = Files.readAllBytes(path);
+        String actual = new String(bytes);
         Files.delete(path);
         Assertions.assertEquals(expected, actual);
     }


### PR DESCRIPTION
According to [a recent article](https://www.itprotoday.com/programming-languages/what-state-java-ecosystem-2023), at least one-third of the Java ecosystem is still comprised of Java 8 applications. The primary choice behind using Java 11 for this library was because of the `java.lang.ref.Cleaner` API, which was introduced in Java 9. This API provides a memory safety net, in cases where the user forgets to appropriately clean up the native resources associated with `External` instances.

Although migrating to Java 8 would no doubt contribute to the overall adoption of the library, the removal of the `Cleaner` API is out of the question. We therefore need to devise alternative means by which we can guarantee native resource cleanup. 