### PR TITLE
Introducing `TreeCursor#gotoNode`

### DIFF
--- a/lib/ch_usi_si_seart_treesitter_TreeCursor.cc
+++ b/lib/ch_usi_si_seart_treesitter_TreeCursor.cc
@@ -126,6 +126,30 @@ JNIEXPORT jboolean JNICALL Java_ch_usi_si_seart_treesitter_TreeCursor_gotoParent
   return result ? JNI_TRUE : JNI_FALSE;
 }
 
+JNIEXPORT jboolean JNICALL Java_ch_usi_si_seart_treesitter_TreeCursor_gotoNode(
+  JNIEnv* env, jobject thisObject, jobject nodeObject) {
+  if (nodeObject == NULL) {
+    __throwNPE(env, "Node must not be null!");
+    return JNI_FALSE;
+  }
+  TSNode target = __unmarshalNode(env, nodeObject);
+  if (ts_node_is_null(target)) {
+    __throwIAE(env, "Node must be part of the tree!");
+    return JNI_FALSE;
+  }
+  TSTreeCursor* cursor = (TSTreeCursor*)__getPointer(env, thisObject);
+  TSNode source = ts_tree_cursor_current_node(cursor);
+  if (ts_node_eq(source, target)) return JNI_FALSE;
+  if (source.tree != target.tree) {
+    __throwIAE(env, "Node must be part of the tree!");
+    return JNI_FALSE;
+  }
+  ts_tree_cursor_reset(cursor, target);
+  env->SetIntField(thisObject, _treeCursorContext0Field, cursor->context[0]);
+  env->SetIntField(thisObject, _treeCursorContext1Field, cursor->context[1]);
+  return JNI_TRUE;
+}
+
 JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_TreeCursor_clone(
   JNIEnv* env, jobject thisObject) {
   jobject treeObject = env->GetObjectField(thisObject, _treeCursorTreeField);

--- a/lib/ch_usi_si_seart_treesitter_TreeCursor.h
+++ b/lib/ch_usi_si_seart_treesitter_TreeCursor.h
@@ -81,6 +81,14 @@ JNIEXPORT jboolean JNICALL Java_ch_usi_si_seart_treesitter_TreeCursor_gotoParent
 
 /*
  * Class:     ch_usi_si_seart_treesitter_TreeCursor
+ * Method:    gotoNode
+ * Signature: (Lch/usi/si/seart/treesitter/Node;)Z
+ */
+JNIEXPORT jboolean JNICALL Java_ch_usi_si_seart_treesitter_TreeCursor_gotoNode
+  (JNIEnv *, jobject, jobject);
+
+/*
+ * Class:     ch_usi_si_seart_treesitter_TreeCursor
  * Method:    clone
  * Signature: ()Lch/usi/si/seart/treesitter/TreeCursor;
  */

--- a/src/main/java/ch/usi/si/seart/treesitter/OffsetTreeCursor.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/OffsetTreeCursor.java
@@ -87,6 +87,11 @@ public class OffsetTreeCursor extends TreeCursor {
     }
 
     @Override
+    public boolean gotoNode(@NotNull Node node) {
+        return cursor.gotoNode(node);
+    }
+
+    @Override
     public void preorderTraversal(@NotNull Consumer<Node> callback) {
         cursor.preorderTraversal(callback);
     }

--- a/src/main/java/ch/usi/si/seart/treesitter/TreeCursor.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/TreeCursor.java
@@ -120,6 +120,18 @@ public class TreeCursor extends External implements Cloneable {
     public native boolean gotoParent();
 
     /**
+     * Move the cursor to an arbitrary node.
+     *
+     * @param node target node to move the cursor to.
+     * @return true if the cursor successfully moved,
+     * and false if it was already at the specified node
+     * @throws NullPointerException if {@code node} is null
+     * @throws IllegalArgumentException if {@code node} is not present in the tree
+     * @since 1.9.0
+     */
+    public native boolean gotoNode(@NotNull Node node);
+
+    /**
      * Iteratively traverse over the parse tree,
      * applying a callback to the nodes before they are visited.
      *

--- a/src/test/java/ch/usi/si/seart/treesitter/TreeCursorTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/TreeCursorTest.java
@@ -118,6 +118,22 @@ class TreeCursorTest extends TestBase {
     }
 
     @Test
+    void testGotoNode() {
+        Node root = tree.getRootNode();
+        Assertions.assertFalse(cursor.gotoNode(root));
+        Node identifier = root.getChild(0).getChildByFieldName("name");
+        Assertions.assertTrue(cursor.gotoNode(identifier));
+        Assertions.assertEquals(identifier, cursor.getCurrentNode());
+        Assertions.assertFalse(cursor.gotoNode(identifier));
+        Assertions.assertTrue(cursor.gotoNode(root));
+        Assertions.assertEquals(root, cursor.getCurrentNode());
+        Node clone = tree.clone().getRootNode();
+        Assertions.assertThrows(NullPointerException.class, () -> cursor.gotoNode(null));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> cursor.gotoNode(empty));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> cursor.gotoNode(clone));
+    }
+
+    @Test
     void testPreorderTraversal() {
         AtomicInteger count = new AtomicInteger();
         cursor.preorderTraversal(node -> {


### PR DESCRIPTION
New navigation method that allows us to reposition the cursor to an arbitrary `Node` of the `Tree`.
One useful use case is repositioning the current `TreeCursor` position back to the root `Node`.