### PR TITLE
Improvements to `QueryCursor`

### DIFF
--- a/lib/ch_usi_si_seart_treesitter_QueryCursor.cc
+++ b/lib/ch_usi_si_seart_treesitter_QueryCursor.cc
@@ -10,7 +10,7 @@ JNIEXPORT void JNICALL Java_ch_usi_si_seart_treesitter_QueryCursor_delete(
   __clearPointer(env, thisObject);
 }
 
-JNIEXPORT void JNICALL Java_ch_usi_si_seart_treesitter_QueryCursor_execute__(
+JNIEXPORT void JNICALL Java_ch_usi_si_seart_treesitter_QueryCursor_execute(
   JNIEnv* env, jobject thisObject) {
   jobject nodeObject = env->GetObjectField(thisObject, _queryCursorNodeField);
   jobject queryObject = env->GetObjectField(thisObject, _queryCursorQueryField);
@@ -21,7 +21,7 @@ JNIEXPORT void JNICALL Java_ch_usi_si_seart_treesitter_QueryCursor_execute__(
   env->SetBooleanField(thisObject, _queryCursorExecutedField, JNI_TRUE);
 }
 
-JNIEXPORT void JNICALL Java_ch_usi_si_seart_treesitter_QueryCursor_execute__II(
+JNIEXPORT void JNICALL Java_ch_usi_si_seart_treesitter_QueryCursor_setRange__II(
   JNIEnv* env, jobject thisObject, jint start, jint end) {
   if (start < 0 || end < 0) {
     __throwIAE(env, "The start and end bytes must not be negative!");
@@ -33,7 +33,6 @@ JNIEXPORT void JNICALL Java_ch_usi_si_seart_treesitter_QueryCursor_execute__II(
   }
   // Not sure why I need to multiply by two, again probably because of utf-16
   jobject nodeObject = env->GetObjectField(thisObject, _queryCursorNodeField);
-  jobject queryObject = env->GetObjectField(thisObject, _queryCursorQueryField);
   TSNode node = __unmarshalNode(env, nodeObject);
   uint32_t nodeStart = ts_node_start_byte(node);
   uint32_t rangeStart = (uint32_t)start * 2;
@@ -47,14 +46,11 @@ JNIEXPORT void JNICALL Java_ch_usi_si_seart_treesitter_QueryCursor_execute__II(
     __throwBOB(env, end);
     return;
   }
-  TSQuery* query = (TSQuery*)__getPointer(env, queryObject);
   TSQueryCursor* cursor = (TSQueryCursor*)__getPointer(env, thisObject);
   ts_query_cursor_set_byte_range(cursor, rangeStart, rangeEnd);
-  ts_query_cursor_exec(cursor, query, node);
-  env->SetBooleanField(thisObject, _queryCursorExecutedField, JNI_TRUE);
 }
 
-JNIEXPORT void JNICALL Java_ch_usi_si_seart_treesitter_QueryCursor_execute__Lch_usi_si_seart_treesitter_Point_2Lch_usi_si_seart_treesitter_Point_2(
+JNIEXPORT void JNICALL Java_ch_usi_si_seart_treesitter_QueryCursor_setRange__Lch_usi_si_seart_treesitter_Point_2Lch_usi_si_seart_treesitter_Point_2(
   JNIEnv* env, jobject thisObject, jobject startPointObject, jobject endPointObject) {
   if (startPointObject == NULL) {
     __throwNPE(env, "Start point must not be null!");
@@ -65,7 +61,6 @@ JNIEXPORT void JNICALL Java_ch_usi_si_seart_treesitter_QueryCursor_execute__Lch_
     return;
   }
   jobject nodeObject = env->GetObjectField(thisObject, _queryCursorNodeField);
-  jobject queryObject = env->GetObjectField(thisObject, _queryCursorQueryField);
   TSNode node = __unmarshalNode(env, nodeObject);
   TSPoint startPoint = __unmarshalPoint(env, startPointObject);
   TSPoint endPoint = __unmarshalPoint(env, endPointObject);
@@ -91,11 +86,8 @@ JNIEXPORT void JNICALL Java_ch_usi_si_seart_treesitter_QueryCursor_execute__Lch_
     __throwPOB(env, endPointObject);
     return;
   }
-  TSQuery* query = (TSQuery*)__getPointer(env, queryObject);
   TSQueryCursor* cursor = (TSQueryCursor*)__getPointer(env, thisObject);
   ts_query_cursor_set_point_range(cursor, startPoint, endPoint);
-  ts_query_cursor_exec(cursor, query, node);
-  env->SetBooleanField(thisObject, _queryCursorExecutedField, JNI_TRUE);
 }
 
 JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_QueryCursor_nextMatch(

--- a/lib/ch_usi_si_seart_treesitter_QueryCursor.cc
+++ b/lib/ch_usi_si_seart_treesitter_QueryCursor.cc
@@ -12,8 +12,6 @@ JNIEXPORT void JNICALL Java_ch_usi_si_seart_treesitter_QueryCursor_delete(
 
 JNIEXPORT void JNICALL Java_ch_usi_si_seart_treesitter_QueryCursor_execute(
   JNIEnv* env, jobject thisObject) {
-  bool executed = (bool)env->GetBooleanField(thisObject, _queryCursorExecutedField);
-  if (executed) return;
   jobject nodeObject = env->GetObjectField(thisObject, _queryCursorNodeField);
   jobject queryObject = env->GetObjectField(thisObject, _queryCursorQueryField);
   TSQueryCursor* cursor = (TSQueryCursor*)__getPointer(env, thisObject);

--- a/lib/ch_usi_si_seart_treesitter_QueryCursor.cc
+++ b/lib/ch_usi_si_seart_treesitter_QueryCursor.cc
@@ -10,13 +10,90 @@ JNIEXPORT void JNICALL Java_ch_usi_si_seart_treesitter_QueryCursor_delete(
   __clearPointer(env, thisObject);
 }
 
-JNIEXPORT void JNICALL Java_ch_usi_si_seart_treesitter_QueryCursor_execute(
+JNIEXPORT void JNICALL Java_ch_usi_si_seart_treesitter_QueryCursor_execute__(
   JNIEnv* env, jobject thisObject) {
   jobject nodeObject = env->GetObjectField(thisObject, _queryCursorNodeField);
   jobject queryObject = env->GetObjectField(thisObject, _queryCursorQueryField);
   TSQueryCursor* cursor = (TSQueryCursor*)__getPointer(env, thisObject);
   TSQuery* query = (TSQuery*)__getPointer(env, queryObject);
   TSNode node = __unmarshalNode(env, nodeObject);
+  ts_query_cursor_exec(cursor, query, node);
+  env->SetBooleanField(thisObject, _queryCursorExecutedField, JNI_TRUE);
+}
+
+JNIEXPORT void JNICALL Java_ch_usi_si_seart_treesitter_QueryCursor_execute__II(
+  JNIEnv* env, jobject thisObject, jint start, jint end) {
+  if (start < 0 || end < 0) {
+    __throwIAE(env, "The start and end bytes must not be negative!");
+    return;
+  }
+  if (start > end) {
+    __throwIAE(env, "The starting byte of the range must not be greater than the ending byte!");
+    return;
+  }
+  // Not sure why I need to multiply by two, again probably because of utf-16
+  jobject nodeObject = env->GetObjectField(thisObject, _queryCursorNodeField);
+  jobject queryObject = env->GetObjectField(thisObject, _queryCursorQueryField);
+  TSNode node = __unmarshalNode(env, nodeObject);
+  uint32_t nodeStart = ts_node_start_byte(node);
+  uint32_t rangeStart = (uint32_t)start * 2;
+  if (rangeStart < nodeStart) {
+    __throwBOB(env, start);
+    return;
+  }
+  uint32_t nodeEnd = ts_node_end_byte(node);
+  uint32_t rangeEnd = (uint32_t)end * 2;
+  if (rangeEnd > nodeEnd) {
+    __throwBOB(env, end);
+    return;
+  }
+  TSQuery* query = (TSQuery*)__getPointer(env, queryObject);
+  TSQueryCursor* cursor = (TSQueryCursor*)__getPointer(env, thisObject);
+  ts_query_cursor_set_byte_range(cursor, rangeStart, rangeEnd);
+  ts_query_cursor_exec(cursor, query, node);
+  env->SetBooleanField(thisObject, _queryCursorExecutedField, JNI_TRUE);
+}
+
+JNIEXPORT void JNICALL Java_ch_usi_si_seart_treesitter_QueryCursor_execute__Lch_usi_si_seart_treesitter_Point_2Lch_usi_si_seart_treesitter_Point_2(
+  JNIEnv* env, jobject thisObject, jobject startPointObject, jobject endPointObject) {
+  if (startPointObject == NULL) {
+    __throwNPE(env, "Start point must not be null!");
+    return;
+  }
+  if (endPointObject == NULL) {
+    __throwNPE(env, "End point must not be null!");
+    return;
+  }
+  jobject nodeObject = env->GetObjectField(thisObject, _queryCursorNodeField);
+  jobject queryObject = env->GetObjectField(thisObject, _queryCursorQueryField);
+  TSNode node = __unmarshalNode(env, nodeObject);
+  TSPoint startPoint = __unmarshalPoint(env, startPointObject);
+  TSPoint endPoint = __unmarshalPoint(env, endPointObject);
+  if (endPoint.row < 0 || endPoint.column < 0) {
+    __throwIAE(env, "End point can not have negative coordinates!");
+    return;
+  }
+  if (startPoint.row < 0 || startPoint.column < 0) {
+    __throwIAE(env, "Start point can not have negative coordinates!");
+    return;
+  }
+  if (__comparePoints(startPoint, endPoint) == GT) {
+    __throwIAE(env, "Start point can not be greater than end point!");
+    return;
+  }
+  TSPoint lowerBound = ts_node_start_point(node);
+  if (__comparePoints(lowerBound, startPoint) == GT) {
+    __throwPOB(env, startPointObject);
+    return;
+  }
+  TSPoint upperBound = ts_node_end_point(node);
+  if (__comparePoints(endPoint, upperBound) == GT) {
+    __throwPOB(env, endPointObject);
+    return;
+  }
+  TSQuery* query = (TSQuery*)__getPointer(env, queryObject);
+  TSQueryCursor* cursor = (TSQueryCursor*)__getPointer(env, thisObject);
+  ts_query_cursor_set_point_range(cursor, startPoint, endPoint);
   ts_query_cursor_exec(cursor, query, node);
   env->SetBooleanField(thisObject, _queryCursorExecutedField, JNI_TRUE);
 }

--- a/lib/ch_usi_si_seart_treesitter_QueryCursor.h
+++ b/lib/ch_usi_si_seart_treesitter_QueryCursor.h
@@ -20,23 +20,23 @@ JNIEXPORT void JNICALL Java_ch_usi_si_seart_treesitter_QueryCursor_delete
  * Method:    execute
  * Signature: ()V
  */
-JNIEXPORT void JNICALL Java_ch_usi_si_seart_treesitter_QueryCursor_execute__
+JNIEXPORT void JNICALL Java_ch_usi_si_seart_treesitter_QueryCursor_execute
   (JNIEnv *, jobject);
 
 /*
  * Class:     ch_usi_si_seart_treesitter_QueryCursor
- * Method:    execute
+ * Method:    setRange
  * Signature: (II)V
  */
-JNIEXPORT void JNICALL Java_ch_usi_si_seart_treesitter_QueryCursor_execute__II
+JNIEXPORT void JNICALL Java_ch_usi_si_seart_treesitter_QueryCursor_setRange__II
   (JNIEnv *, jobject, jint, jint);
 
 /*
  * Class:     ch_usi_si_seart_treesitter_QueryCursor
- * Method:    execute
+ * Method:    setRange
  * Signature: (Lch/usi/si/seart/treesitter/Point;Lch/usi/si/seart/treesitter/Point;)V
  */
-JNIEXPORT void JNICALL Java_ch_usi_si_seart_treesitter_QueryCursor_execute__Lch_usi_si_seart_treesitter_Point_2Lch_usi_si_seart_treesitter_Point_2
+JNIEXPORT void JNICALL Java_ch_usi_si_seart_treesitter_QueryCursor_setRange__Lch_usi_si_seart_treesitter_Point_2Lch_usi_si_seart_treesitter_Point_2
   (JNIEnv *, jobject, jobject, jobject);
 
 /*

--- a/lib/ch_usi_si_seart_treesitter_QueryCursor.h
+++ b/lib/ch_usi_si_seart_treesitter_QueryCursor.h
@@ -20,8 +20,24 @@ JNIEXPORT void JNICALL Java_ch_usi_si_seart_treesitter_QueryCursor_delete
  * Method:    execute
  * Signature: ()V
  */
-JNIEXPORT void JNICALL Java_ch_usi_si_seart_treesitter_QueryCursor_execute
+JNIEXPORT void JNICALL Java_ch_usi_si_seart_treesitter_QueryCursor_execute__
   (JNIEnv *, jobject);
+
+/*
+ * Class:     ch_usi_si_seart_treesitter_QueryCursor
+ * Method:    execute
+ * Signature: (II)V
+ */
+JNIEXPORT void JNICALL Java_ch_usi_si_seart_treesitter_QueryCursor_execute__II
+  (JNIEnv *, jobject, jint, jint);
+
+/*
+ * Class:     ch_usi_si_seart_treesitter_QueryCursor
+ * Method:    execute
+ * Signature: (Lch/usi/si/seart/treesitter/Point;Lch/usi/si/seart/treesitter/Point;)V
+ */
+JNIEXPORT void JNICALL Java_ch_usi_si_seart_treesitter_QueryCursor_execute__Lch_usi_si_seart_treesitter_Point_2Lch_usi_si_seart_treesitter_Point_2
+  (JNIEnv *, jobject, jobject, jobject);
 
 /*
  * Class:     ch_usi_si_seart_treesitter_QueryCursor

--- a/src/main/java/ch/usi/si/seart/treesitter/QueryCursor.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/QueryCursor.java
@@ -39,8 +39,7 @@ public class QueryCursor extends External implements Iterable<QueryMatch> {
     protected native void delete();
 
     /**
-     * Start running a given query on a given node.
-     * Successive calls to this method are ignored.
+     * Start running a query against a node.
      */
     public native void execute();
 
@@ -48,7 +47,8 @@ public class QueryCursor extends External implements Iterable<QueryMatch> {
      * Advance to the next match of the currently running query.
      *
      * @return A match if there is one, null otherwise
-     * @throws IllegalStateException if {@link #execute()} was not called beforehand
+     * @throws IllegalStateException if the query was not executed beforehand
+     * @see #execute()
      */
     public native QueryMatch nextMatch();
 

--- a/src/main/java/ch/usi/si/seart/treesitter/QueryCursor.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/QueryCursor.java
@@ -44,8 +44,7 @@ public class QueryCursor extends External implements Iterable<QueryMatch> {
     public native void execute();
 
     /**
-     * Start running a query against a node,
-     * limiting search to a range of bytes.
+     * Set the range of bytes positions in which the query will be executed.
      *
      * @param startByte The start byte of the query range
      * @param endByte The end byte of the query range
@@ -59,11 +58,10 @@ public class QueryCursor extends External implements Iterable<QueryMatch> {
      * </ul>
      * @since 1.9.0
      */
-    public native void execute(int startByte, int endByte);
+    public native void setRange(int startByte, int endByte);
 
     /**
-     * Start running a query against a node,
-     * limiting the search to a range between two points.
+     * Set the range of row-column coordinates in which the query will be executed.
      *
      * @param startPoint The start point of the query range
      * @param endPoint The end point of the query range
@@ -74,7 +72,7 @@ public class QueryCursor extends External implements Iterable<QueryMatch> {
      * if any of the arguments is outside the queried node's position range
      * @since 1.9.0
      */
-    public native void execute(@NotNull Point startPoint, @NotNull Point endPoint);
+    public native void setRange(@NotNull Point startPoint, @NotNull Point endPoint);
 
     /**
      * Advance to the next match of the currently running query.
@@ -82,13 +80,15 @@ public class QueryCursor extends External implements Iterable<QueryMatch> {
      * @return A match if there is one, null otherwise
      * @throws IllegalStateException if the query was not executed beforehand
      * @see #execute()
-     * @see #execute(int, int)
-     * @see #execute(Point, Point)
      */
     public native QueryMatch nextMatch();
 
     /**
-     * @return An iterator over the query cursor matches, starting from the first match
+     * Returns an iterator over the query matches,
+     * starting from the first {@link QueryMatch}.
+     * Implicitly calls {@link #execute()}.
+     *
+     * @return an iterator over query cursor matches
      */
     @Override
     public @NotNull Iterator<QueryMatch> iterator() {

--- a/src/main/java/ch/usi/si/seart/treesitter/QueryCursor.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/QueryCursor.java
@@ -44,11 +44,46 @@ public class QueryCursor extends External implements Iterable<QueryMatch> {
     public native void execute();
 
     /**
+     * Start running a query against a node,
+     * limiting search to a range of bytes.
+     *
+     * @param startByte The start byte of the query range
+     * @param endByte The end byte of the query range
+     * @throws ch.usi.si.seart.treesitter.exception.ByteOffsetOutOfBoundsException
+     * if either argument is outside the queried node's byte range
+     * @throws IllegalArgumentException if:
+     * <ul>
+     *     <li>{@code startByte} &lt; 0</li>
+     *     <li>{@code endByte} &lt; 0</li>
+     *     <li>{@code startByte} &gt; {@code endByte}</li>
+     * </ul>
+     * @since 1.9.0
+     */
+    public native void execute(int startByte, int endByte);
+
+    /**
+     * Start running a query against a node,
+     * limiting the search to a range between two points.
+     *
+     * @param startPoint The start point of the query range
+     * @param endPoint The end point of the query range
+     * @throws NullPointerException if either argument is null
+     * @throws IllegalArgumentException if any point coordinates are negative,
+     * or if {@code startPoint} is a position that comes after {@code endPoint}
+     * @throws ch.usi.si.seart.treesitter.exception.PointOutOfBoundsException
+     * if any of the arguments is outside the queried node's position range
+     * @since 1.9.0
+     */
+    public native void execute(@NotNull Point startPoint, @NotNull Point endPoint);
+
+    /**
      * Advance to the next match of the currently running query.
      *
      * @return A match if there is one, null otherwise
      * @throws IllegalStateException if the query was not executed beforehand
      * @see #execute()
+     * @see #execute(int, int)
+     * @see #execute(Point, Point)
      */
     public native QueryMatch nextMatch();
 

--- a/src/test/java/ch/usi/si/seart/treesitter/QueryCursorTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/QueryCursorTest.java
@@ -148,10 +148,12 @@ class QueryCursorTest extends TestBase {
         for (Node comment: comments) {
             int lowerByte = comment.getStartByte();
             int upperByte = comment.getEndByte();
-            cursor.execute(lowerByte, upperByte);
+            cursor.setRange(lowerByte, upperByte);
+            Iterator<QueryMatch> iterator = cursor.iterator();
             Assertions.assertTrue(cursor.isExecuted());
-            Assertions.assertNotNull(cursor.nextMatch());
-            Assertions.assertNull(cursor.nextMatch());
+            Assertions.assertTrue(iterator.hasNext());
+            Assertions.assertNotNull(iterator.next());
+            Assertions.assertFalse(iterator.hasNext());
         }
     }
 
@@ -173,7 +175,7 @@ class QueryCursorTest extends TestBase {
     @ArgumentsSource(ByteRangeExceptionProvider.class)
     void testExecuteByteRangeThrows(Class<Throwable> throwableType, int startByte, int endByte) {
         @Cleanup QueryCursor cursor = body.walk(query);
-        Assertions.assertThrows(throwableType, () -> cursor.execute(startByte, endByte));
+        Assertions.assertThrows(throwableType, () -> cursor.setRange(startByte, endByte));
     }
 
     @Test
@@ -186,10 +188,12 @@ class QueryCursorTest extends TestBase {
         for (Node comment: comments) {
             Point lowerPoint = comment.getStartPoint();
             Point upperPoint = comment.getEndPoint();
-            cursor.execute(lowerPoint, upperPoint);
+            cursor.setRange(lowerPoint, upperPoint);
+            Iterator<QueryMatch> iterator = cursor.iterator();
             Assertions.assertTrue(cursor.isExecuted());
-            Assertions.assertNotNull(cursor.nextMatch());
-            Assertions.assertNull(cursor.nextMatch());
+            Assertions.assertTrue(iterator.hasNext());
+            Assertions.assertNotNull(iterator.next());
+            Assertions.assertFalse(iterator.hasNext());
         }
     }
 
@@ -212,7 +216,7 @@ class QueryCursorTest extends TestBase {
     @ArgumentsSource(PointRangeExceptionProvider.class)
     void testExecutePointRangeThrows(Class<Throwable> throwableType, Point startPoint, Point endPoint) {
         @Cleanup QueryCursor cursor = body.walk(query);
-        Assertions.assertThrows(throwableType, () -> cursor.execute(startPoint, endPoint));
+        Assertions.assertThrows(throwableType, () -> cursor.setRange(startPoint, endPoint));
     }
 
     @Test

--- a/src/test/java/ch/usi/si/seart/treesitter/QueryCursorTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/QueryCursorTest.java
@@ -127,16 +127,17 @@ class QueryCursorTest extends TestBase {
     }
 
     @Test
-    void testMultipleExecuteCalls() {
+    void testExecuteReuse() {
         @Cleanup Query query = Query.getFor(language, "(class_body) @class");
         @Cleanup QueryCursor cursor = root.walk(query);
         Assertions.assertFalse(cursor.isExecuted());
         cursor.execute();
         Assertions.assertTrue(cursor.isExecuted());
+        Assertions.assertNotNull(cursor.nextMatch());
+        Assertions.assertNull(cursor.nextMatch());
         cursor.execute();
         Assertions.assertTrue(cursor.isExecuted());
-        QueryMatch match = cursor.nextMatch();
-        Assertions.assertNotNull(match);
+        Assertions.assertNotNull(cursor.nextMatch());
         Assertions.assertNull(cursor.nextMatch());
     }
 


### PR DESCRIPTION
Contains two major changes to `execute` APIs of `QueryCursor`:
- Cursor will now reset on successive calls to `execute`, as opposed to doing nothing;
- Two overloaded `setRange` methods were added to support narrower searches (by `byte` and `Point` range).