### PR TITLE
Add "null" variants of `Node` and `TreeCursor`

### DIFF
--- a/src/main/java/ch/usi/si/seart/treesitter/External.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/External.java
@@ -2,22 +2,19 @@ package ch.usi.si.seart.treesitter;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
 import lombok.experimental.FieldDefaults;
 
 import java.lang.ref.Cleaner;
 
 @FieldDefaults(makeFinal = true)
+@NoArgsConstructor(access = AccessLevel.PROTECTED, force = true)
 abstract class External implements AutoCloseable {
 
     protected long pointer;
     private Cleaner.Cleanable cleanable;
 
     private static final Cleaner CLEANER = Cleaner.create();
-
-    protected External() {
-        this.pointer = 0L;
-        this.cleanable = null;
-    }
 
     protected External(long pointer) {
         this.pointer = pointer;

--- a/src/main/java/ch/usi/si/seart/treesitter/Node.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Node.java
@@ -25,7 +25,7 @@ import java.util.NoSuchElementException;
  * @author Ozren Dabić
  */
 @AllArgsConstructor(access = AccessLevel.PACKAGE)
-@NoArgsConstructor(access = AccessLevel.PACKAGE, force = true)
+@NoArgsConstructor(access = AccessLevel.PRIVATE, force = true)
 @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
 public class Node implements Iterable<Node> {
 

--- a/src/main/java/ch/usi/si/seart/treesitter/Node.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Node.java
@@ -3,6 +3,7 @@ package ch.usi.si.seart.treesitter;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Generated;
+import lombok.NoArgsConstructor;
 import lombok.experimental.FieldDefaults;
 import org.jetbrains.annotations.NotNull;
 
@@ -24,6 +25,7 @@ import java.util.NoSuchElementException;
  * @author Ozren Dabić
  */
 @AllArgsConstructor(access = AccessLevel.PACKAGE)
+@NoArgsConstructor(access = AccessLevel.PACKAGE, force = true)
 @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
 public class Node implements Iterable<Node> {
 
@@ -35,10 +37,6 @@ public class Node implements Iterable<Node> {
     long id;
 
     Tree tree;
-
-    Node() {
-        this(0, 0, 0, 0, 0L, null);
-    }
 
     static class Null extends Node {
     }

--- a/src/main/java/ch/usi/si/seart/treesitter/Node.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Node.java
@@ -40,6 +40,9 @@ public class Node implements Iterable<Node> {
         this(0, 0, 0, 0, 0L, null);
     }
 
+    static class Null extends Node {
+    }
+
     /**
      * Get the node's child at the given index,
      * where zero represents the first child.

--- a/src/main/java/ch/usi/si/seart/treesitter/OffsetTreeCursor.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/OffsetTreeCursor.java
@@ -33,7 +33,7 @@ import java.util.stream.Collectors;
  * @author Ozren Dabić
  */
 @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
-public class OffsetTreeCursor extends TreeCursor {
+public class OffsetTreeCursor extends TreeCursor.Stub {
 
     private static final String UOE_MESSAGE_1 = "Byte positions not available after node position has changed!";
     private static final String UOE_MESSAGE_2 = "Byte position searches not supported after node position has changed!";
@@ -44,7 +44,6 @@ public class OffsetTreeCursor extends TreeCursor {
     Point offset;
 
     public OffsetTreeCursor(@NotNull Node node, @NotNull Point offset) {
-        super();
         Objects.requireNonNull(node, "Node must not be null!");
         Objects.requireNonNull(offset, "Offset must not be null!");
         this.cursor = node.walk();

--- a/src/main/java/ch/usi/si/seart/treesitter/OffsetTreeCursor.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/OffsetTreeCursor.java
@@ -103,7 +103,7 @@ public class OffsetTreeCursor extends TreeCursor {
 
     @AllArgsConstructor(access = AccessLevel.PACKAGE)
     @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
-    private class OffsetNode extends Node {
+    private class OffsetNode extends Node.Null {
 
         Node node;
 

--- a/src/main/java/ch/usi/si/seart/treesitter/TreeCursor.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/TreeCursor.java
@@ -1,6 +1,7 @@
 package ch.usi.si.seart.treesitter;
 
 import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import lombok.experimental.FieldDefaults;
 import org.jetbrains.annotations.NotNull;
 
@@ -16,6 +17,7 @@ import java.util.function.Consumer;
  * @author Tommy MacWilliam
  * @author Ozren Dabić
  */
+@NoArgsConstructor(access = AccessLevel.PRIVATE, force = true)
 @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
 public class TreeCursor extends External implements Cloneable {
 
@@ -25,18 +27,6 @@ public class TreeCursor extends External implements Cloneable {
     long id;
 
     Tree tree;
-
-    /*
-     * This is a workaround intended for OffsetTreeCursor.
-     * Should not be used under any other circumstances!
-     */
-    protected TreeCursor() {
-        super();
-        this.context0 = 0;
-        this.context1 = 0;
-        this.id = 0L;
-        this.tree = null;
-    }
 
     @SuppressWarnings("unused")
     TreeCursor(long pointer, int context0, int context1, long id, @NotNull Tree tree) {

--- a/src/main/java/ch/usi/si/seart/treesitter/TreeCursor.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/TreeCursor.java
@@ -145,4 +145,57 @@ public class TreeCursor extends External implements Cloneable {
      */
     @Override
     public native TreeCursor clone();
+
+    static class Stub extends TreeCursor {
+
+        @Override
+        public Node getCurrentNode() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String getCurrentFieldName() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public TreeCursorNode getCurrentTreeCursorNode() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean gotoFirstChild() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean gotoFirstChild(int offset) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean gotoFirstChild(@NotNull Point point) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean gotoNextSibling() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean gotoParent() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void preorderTraversal(@NotNull Consumer<Node> callback) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public TreeCursor clone() {
+            throw new UnsupportedOperationException();
+        }
+    }
 }

--- a/src/test/java/ch/usi/si/seart/treesitter/TestBase.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/TestBase.java
@@ -2,7 +2,7 @@ package ch.usi.si.seart.treesitter;
 
 public abstract class TestBase {
 
-    protected final Node empty = new Node();
+    protected final Node empty = new Node.Null();
     protected final Node treeless = new Node(1, 1, 1, 1, 1L, null);
     protected final Point _0_0_ = new Point(0, 0);
     protected final Point _0_1_ = new Point(0, 1);


### PR DESCRIPTION
This PR introduces the following inner classes:
- `Node#Null`
- `TreeCursor#Stub`

They are intended for internal use in inheritance hierarchies. With the introduction of these specialized classes, the no-arg constructors of `Node` and `TreeCursor` have seen their visibility reduced to `private`.