### PR TITLE
Added missing `clone` implementation to `OffsetTreeCursor`

### DIFF
--- a/src/main/java/ch/usi/si/seart/treesitter/OffsetTreeCursor.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/OffsetTreeCursor.java
@@ -97,6 +97,11 @@ public class OffsetTreeCursor extends TreeCursor {
     }
 
     @Override
+    public TreeCursor clone() {
+        return new OffsetTreeCursor(cursor.getCurrentNode(), offset);
+    }
+
+    @Override
     public String toString() {
         return String.format("OffsetTreeCursor(row: %d, column: %d)", offset.getRow(), offset.getColumn());
     }

--- a/src/test/java/ch/usi/si/seart/treesitter/TreeCursorTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/TreeCursorTest.java
@@ -131,6 +131,8 @@ class TreeCursorTest extends TestBase {
     void testClone() {
         @Cleanup TreeCursor copy = cursor.clone();
         Assertions.assertNotEquals(cursor, copy);
+        Assertions.assertEquals(tree.getRootNode(), copy.getCurrentNode());
+        Assertions.assertEquals(cursor.getCurrentNode(), copy.getCurrentNode());
     }
 
     @Test

--- a/src/test/java/ch/usi/si/seart/treesitter/TreeCursorTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/TreeCursorTest.java
@@ -136,6 +136,16 @@ class TreeCursorTest extends TestBase {
     }
 
     @Test
+    void testCloneAfterTraversal() {
+        cursor.gotoFirstChild(); // function_definition
+        cursor.gotoFirstChild(); // identifier
+        @Cleanup TreeCursor copy = cursor.clone();
+        Assertions.assertNotEquals(cursor, copy);
+        Assertions.assertNotEquals(tree.getRootNode(), copy.getCurrentNode());
+        Assertions.assertEquals(cursor.getCurrentNode(), copy.getCurrentNode());
+    }
+
+    @Test
     void testWalkThrows() {
         Assertions.assertThrows(IllegalStateException.class, empty::walk);
     }

--- a/src/test/java/ch/usi/si/seart/treesitter/TreeCursorTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/TreeCursorTest.java
@@ -84,8 +84,8 @@ class TreeCursorTest extends TestBase {
     @Test
     void testGotoFirstChildByteOffsetThrows() {
         cursor.gotoFirstChild(); // function_definition
-        cursor.gotoFirstChild(); // identifier
-        cursor.gotoNextSibling(); // parameters
+        cursor.gotoFirstChild(); // def
+        cursor.gotoNextSibling(); // identifier
         Assertions.assertThrows(IllegalArgumentException.class, () -> cursor.gotoFirstChild(-1));
         Assertions.assertThrows(ByteOffsetOutOfBoundsException.class, () -> cursor.gotoFirstChild(0));
         Assertions.assertThrows(ByteOffsetOutOfBoundsException.class, () -> cursor.gotoFirstChild(20));
@@ -106,8 +106,8 @@ class TreeCursorTest extends TestBase {
     @Test
     void testGotoFirstChildPositionOffsetThrows() {
         cursor.gotoFirstChild(); // function_definition
-        cursor.gotoFirstChild(); // identifier
-        cursor.gotoNextSibling(); // parameters
+        cursor.gotoFirstChild(); // def
+        cursor.gotoNextSibling(); // identifier
         Point negative = new Point(0, -1);
         Point illegal = new Point(1, 2);
         Assertions.assertThrows(NullPointerException.class, () -> cursor.gotoFirstChild(null));
@@ -138,7 +138,7 @@ class TreeCursorTest extends TestBase {
     @Test
     void testCloneAfterTraversal() {
         cursor.gotoFirstChild(); // function_definition
-        cursor.gotoFirstChild(); // identifier
+        cursor.gotoFirstChild(); // def
         @Cleanup TreeCursor copy = cursor.clone();
         Assertions.assertNotEquals(cursor, copy);
         Assertions.assertNotEquals(tree.getRootNode(), copy.getCurrentNode());


### PR DESCRIPTION
The lack of call delegation could potentially cause a `SIGSEGV`.