### PR TITLE
Add method for obtaining the `Language` of a `Node`

### DIFF
--- a/src/main/java/ch/usi/si/seart/treesitter/Node.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Node.java
@@ -192,6 +192,16 @@ public class Node implements Iterable<Node> {
     }
 
     /**
+     * Get the {@link Language} that was used to parse this node’s syntax tree.
+     *
+     * @return the node's language
+     * @since 1.9.0
+     */
+    public Language getLanguage() {
+        return !isNull() ? tree.getLanguage() : null;
+    }
+
+    /**
      * Get the <em>named</em> child {@code Node} at the given index.
      *
      * @param child the zero-indexed child position

--- a/src/main/java/ch/usi/si/seart/treesitter/OffsetTreeCursor.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/OffsetTreeCursor.java
@@ -185,6 +185,11 @@ public class OffsetTreeCursor extends TreeCursor.Stub {
         }
 
         @Override
+        public Language getLanguage() {
+            return node.getLanguage();
+        }
+
+        @Override
         public Node getNamedChild(int child) {
             return new OffsetNode(node.getNamedChild(child));
         }

--- a/src/test/java/ch/usi/si/seart/treesitter/NodeTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/NodeTest.java
@@ -231,6 +231,13 @@ class NodeTest extends TestBase {
         Assertions.assertThrows(ByteOffsetOutOfBoundsException.class, () -> root.getFirstNamedChildForByte(index));
     }
 
+    @Test
+    void testGetLanguage() {
+        for (Node child: tree)
+            Assertions.assertEquals(tree.getLanguage(), child.getLanguage());
+        Assertions.assertNull(empty.getLanguage());
+    }
+
     @ParameterizedTest
     @MethodSource("provideOutOfBoundsIndexes")
     void testGetNamedChildThrows(int index) {


### PR DESCRIPTION
Inspired by the same functionality from the [Rust binding](https://docs.rs/tree-sitter/latest/src/tree_sitter/lib.rs.html#843-845).