### PR TITLE
Simplified native implementation for `getPrevSibling` and `getNextSibling` of `Node`

### DIFF
--- a/lib/ch_usi_si_seart_treesitter_Node.cc
+++ b/lib/ch_usi_si_seart_treesitter_Node.cc
@@ -197,30 +197,13 @@ JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getFirstChildForB
   return childObject;
 }
 
-JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getNextNamedSibling(
-  JNIEnv* env, jobject thisObject) {
-  TSNode node = __unmarshalNode(env, thisObject);
-  TSNode sibling = ts_node_next_named_sibling(node);
-  if (ts_node_is_null(sibling)) return NULL;
-  jobject siblingObject = __marshalNode(env, sibling);
-  __copyTree(env, thisObject, siblingObject);
-  return siblingObject;
-}
-
 JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getNextSibling(
-  JNIEnv* env, jobject thisObject) {
+  JNIEnv* env, jobject thisObject, jboolean named) {
+  TSNode (*next_sibling_getter)(TSNode) = (bool)named
+        ? ts_node_next_named_sibling
+        : ts_node_next_sibling;
   TSNode node = __unmarshalNode(env, thisObject);
-  TSNode sibling = ts_node_next_sibling(node);
-  if (ts_node_is_null(sibling)) return NULL;
-  jobject siblingObject = __marshalNode(env, sibling);
-  __copyTree(env, thisObject, siblingObject);
-  return siblingObject;
-}
-
-JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getPrevNamedSibling(
-  JNIEnv* env, jobject thisObject) {
-  TSNode node = __unmarshalNode(env, thisObject);
-  TSNode sibling = ts_node_prev_named_sibling(node);
+  TSNode sibling = next_sibling_getter(node);
   if (ts_node_is_null(sibling)) return NULL;
   jobject siblingObject = __marshalNode(env, sibling);
   __copyTree(env, thisObject, siblingObject);
@@ -228,9 +211,12 @@ JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getPrevNamedSibli
 }
 
 JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getPrevSibling(
-  JNIEnv* env, jobject thisObject) {
+  JNIEnv* env, jobject thisObject, jboolean named) {
+  TSNode (*prev_sibling_getter)(TSNode) = (bool)named
+       ? ts_node_prev_named_sibling
+       : ts_node_prev_sibling;
   TSNode node = __unmarshalNode(env, thisObject);
-  TSNode sibling = ts_node_prev_sibling(node);
+  TSNode sibling = prev_sibling_getter(node);
   if (ts_node_is_null(sibling)) return NULL;
   jobject siblingObject = __marshalNode(env, sibling);
   __copyTree(env, thisObject, siblingObject);

--- a/lib/ch_usi_si_seart_treesitter_Node.h
+++ b/lib/ch_usi_si_seart_treesitter_Node.h
@@ -89,35 +89,19 @@ JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getFirstChildForB
 
 /*
  * Class:     ch_usi_si_seart_treesitter_Node
- * Method:    getNextNamedSibling
- * Signature: ()Lch/usi/si/seart/treesitter/Node;
- */
-JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getNextNamedSibling
-  (JNIEnv *, jobject);
-
-/*
- * Class:     ch_usi_si_seart_treesitter_Node
  * Method:    getNextSibling
- * Signature: ()Lch/usi/si/seart/treesitter/Node;
+ * Signature: (Z)Lch/usi/si/seart/treesitter/Node;
  */
 JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getNextSibling
-  (JNIEnv *, jobject);
-
-/*
- * Class:     ch_usi_si_seart_treesitter_Node
- * Method:    getPrevNamedSibling
- * Signature: ()Lch/usi/si/seart/treesitter/Node;
- */
-JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getPrevNamedSibling
-  (JNIEnv *, jobject);
+  (JNIEnv *, jobject, jboolean);
 
 /*
  * Class:     ch_usi_si_seart_treesitter_Node
  * Method:    getPrevSibling
- * Signature: ()Lch/usi/si/seart/treesitter/Node;
+ * Signature: (Z)Lch/usi/si/seart/treesitter/Node;
  */
 JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getPrevSibling
-  (JNIEnv *, jobject);
+  (JNIEnv *, jobject, jboolean);
 
 /*
  * Class:     ch_usi_si_seart_treesitter_Node

--- a/src/main/java/ch/usi/si/seart/treesitter/Node.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Node.java
@@ -278,28 +278,40 @@ public class Node implements Iterable<Node> {
      *
      * @return the next named sibling, {@code null} if there is none
      */
-    public native Node getNextNamedSibling();
+    public Node getNextNamedSibling() {
+        return getNextSibling(true);
+    }
 
     /**
      * Get the next sibling {@code Node}.
      *
      * @return the next sibling, {@code null} if there is none
      */
-    public native Node getNextSibling();
+    public Node getNextSibling() {
+        return getNextSibling(false);
+    }
+
+    private native Node getNextSibling(boolean named);
 
     /**
      * Get the previous <em>named</em> sibling {@code Node}.
      *
      * @return the previous named sibling, {@code null} if there is none
      */
-    public native Node getPrevNamedSibling();
+    public Node getPrevNamedSibling() {
+        return getPrevSibling(true);
+    }
 
     /**
      * Get the previous sibling {@code Node}.
      *
      * @return the previous sibling, {@code null} if there is none
      */
-    public native Node getPrevSibling();
+    public Node getPrevSibling() {
+        return getPrevSibling(false);
+    }
+
+    public native Node getPrevSibling(boolean named);
 
     /**
      * Get the parent {@code Node}.


### PR DESCRIPTION
This includes the regular and "named" variants:
- `getPrevSibling`
- `getPrevNamedSibling`
- `getNextSibling`
- `getNextNamedSibling`