### PR TITLE
Fix incorrect behaviour of `Language#associatedWith` when files have an empty name 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,11 @@
       <version>4.4</version>
     </dependency>
     <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.15.0</version>
+    </dependency>
+    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <version>1.18.30</version>

--- a/src/main/java/ch/usi/si/seart/treesitter/Language.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Language.java
@@ -5,6 +5,7 @@ import lombok.AccessLevel;
 import lombok.Generated;
 import lombok.Getter;
 import lombok.experimental.FieldDefaults;
+import org.apache.commons.io.FilenameUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.TestOnly;
 
@@ -459,8 +460,8 @@ public enum Language {
                 "Path argument must not be a directory!"
         );
         String name = path.getFileName().toString();
-        int i = name.lastIndexOf('.');
-        return Optional.ofNullable(i > 0 ? name.substring(i + 1) : null)
+        String extension = FilenameUtils.getExtension(name);
+        return Optional.of(extension)
                 .map(EXTENSION_LOOKUP::get)
                 .orElseGet(Collections::emptyList);
     }

--- a/src/test/java/ch/usi/si/seart/treesitter/LanguageTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/LanguageTest.java
@@ -59,6 +59,7 @@ class LanguageTest extends TestBase {
         public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) {
             return Stream.of(
                     Arguments.of("requirements.txt", List.of()),
+                    Arguments.of(".py", List.of(Language.PYTHON)),
                     Arguments.of("__init__.py", List.of(Language.PYTHON)),
                     Arguments.of("Main.java", List.of(Language.JAVA)),
                     Arguments.of("example.h", List.of(


### PR DESCRIPTION
Files with empty names like `.py` or `.gitignore` were not be properly mapped to their respective `Language`.