### PR TITLE
Update language binding: `tree-sitter-java`

### DIFF
--- a/src/test/java/ch/usi/si/seart/treesitter/OffsetTreeCursorTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/OffsetTreeCursorTest.java
@@ -50,7 +50,8 @@ class OffsetTreeCursorTest extends PrinterTestBase {
                 "          field: identifier [4:13] - [4:16]\n" +
                 "        name: identifier [4:17] - [4:24]\n" +
                 "        arguments: argument_list [4:24] - [4:41]\n" +
-                "          string_literal [4:25] - [4:40]\n";
+                "          string_literal [4:25] - [4:40]\n" +
+                "            string_fragment [4:26] - [4:39]\n";
     }
 
     @Override

--- a/src/test/java/ch/usi/si/seart/treesitter/printer/DotGraphPrinterTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/printer/DotGraphPrinterTest.java
@@ -54,7 +54,7 @@ class DotGraphPrinterTest extends TestBase {
     }
 
     private void assertion(String result) {
-        Assertions.assertEquals(594, result.lines().count());
+        Assertions.assertEquals(626, result.lines().count());
         Assertions.assertTrue(result.startsWith("digraph tree {"));
         Assertions.assertTrue(result.endsWith("}\n"));
     }

--- a/src/test/java/ch/usi/si/seart/treesitter/printer/SymbolicExpressionPrinterTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/printer/SymbolicExpressionPrinterTest.java
@@ -44,7 +44,9 @@ class SymbolicExpressionPrinterTest extends PrinterTestBase {
                                             ") " +
                                             "name: (identifier) " +
                                             "arguments: (argument_list " +
-                                                "(string_literal)" +
+                                                "(string_literal " +
+                                                    "(string_fragment)" +
+                                                ")" +
                                             ")" +
                                         ")" +
                                     ")" +

--- a/src/test/java/ch/usi/si/seart/treesitter/printer/SyntaxTreePrinterTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/printer/SyntaxTreePrinterTest.java
@@ -36,7 +36,8 @@ class SyntaxTreePrinterTest extends PrinterTestBase {
                 "                field: identifier [5:15] - [5:18]\n" +
                 "              name: identifier [5:19] - [5:26]\n" +
                 "              arguments: argument_list [5:26] - [5:43]\n" +
-                "                string_literal [5:27] - [5:42]\n";
+                "                string_literal [5:27] - [5:42]\n" +
+                "                  string_fragment [5:28] - [5:41]\n";
     }
 
     @Override

--- a/src/test/java/ch/usi/si/seart/treesitter/printer/XMLPrinterTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/printer/XMLPrinterTest.java
@@ -60,6 +60,8 @@ class XMLPrinterTest extends PrinterTestBase {
                                             "</identifier>" +
                                             "<argument_list name=\"arguments\" start=\"5:26\" end=\"5:43\">" +
                                                 "<string_literal start=\"5:27\" end=\"5:42\">" +
+                                                    "<string_fragment start=\"5:28\" end=\"5:41\">" +
+                                                    "</string_fragment>" +
                                                 "</string_literal>" +
                                             "</argument_list>" +
                                         "</method_invocation>" +


### PR DESCRIPTION
Upgrading the language submodule to the latest release. Said release contains some drastic changes related to strings. What was once a node of type `string` is now a `string_literal` comprised of `string_fragment`, `escape_sequence` and `string_interpolation`. Since we test various features like the `printer` classes with Java source code, the tests had to be updated to reflect the aforementioned grammar changes.