### PR TITLE
Update build script to use `subprocess` instead of `system.cmd`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,14 @@
+# Ignore everything...
 *
+
+# ...except these files and directories...
 !/lib
 !/include
 !/tree-sitter*
 !/build.py
+
+# ...on second thought, ignore these files too.
+**/*.so
+**/*.dylib
+**/*.o
+**/*.a

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,9 @@ ENV IMAGE_NAME="seart-group/java-tree-sitter" \
     IMAGE_REPO_URL="https://github.com/${IMAGE_NAME}/" \
     JAVA_HOME="/usr/lib/jvm/java-11-openjdk"
 
-RUN apk update && \
-    apk add --no-cache \
+RUN apk update --quiet && \
+    apk add --quiet \
+            --no-cache \
             openjdk11 \
             python3 \
             py3-distutils-extra \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest AS build
+FROM alpine:3.19.0 AS build
 LABEL maintainer="Ozren Dabić (dabico@usi.ch)"
 
 ENV IMAGE_NAME="seart-group/java-tree-sitter" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,11 @@ ENV IMAGE_NAME="seart-group/java-tree-sitter" \
 RUN apk update --quiet && \
     apk add --quiet \
             --no-cache \
+            alpine-sdk \
+            make \
             openjdk11 \
             python3 \
-            py3-distutils-extra \
-            make \
-            g++
+            py3-distutils-extra
 
 WORKDIR /java-tree-sitter
 COPY . ./

--- a/build.py
+++ b/build.py
@@ -43,8 +43,12 @@ def build(repositories, output_path="libjava-tree-sitter", system=None, arch=Non
 
     tree_sitter = path(here, "tree-sitter")
     redirect = DEVNULL if not verbose else None
-    cmd(["make", "-C", tree_sitter, "clean"], stdout=redirect)
-    cmd(["make", "-C", tree_sitter], stdout=redirect, env=env)
+    code = cmd(["make", "-C", tree_sitter, "clean"], stdout=redirect)
+    if code != 0:
+        raise RuntimeError("Failed to clean tree-sitter library.")
+    code = cmd(["make", "-C", tree_sitter], stdout=redirect, env=env)
+    if code != 0:
+        raise RuntimeError("Failed to build tree-sitter library.")
 
     source_paths = find(path(here, "lib", "*.cc"))
 

--- a/build.py
+++ b/build.py
@@ -56,12 +56,12 @@ def build(repositories, output_path="libjava-tree-sitter", system=None, arch=Non
         repository_macro = f"TS_LANGUAGE_{repository_language.replace('-', '_').upper()}"
         compiler.define_macro(repository_macro, "1")
         match repository_name:
-            case "tree-sitter-dtd" |\
-                 "tree-sitter-markdown" |\
+            case "tree-sitter-dtd" | \
+                 "tree-sitter-markdown" | \
                  "tree-sitter-xml":
                 src_path = path(repository, repository_name, "src")
-            case "tree-sitter-ocaml" |\
-                 "tree-sitter-tsx" |\
+            case "tree-sitter-ocaml" | \
+                 "tree-sitter-tsx" | \
                  "tree-sitter-typescript":
                 src_path = path(repository, repository_language, "src")
             case _:


### PR DESCRIPTION
Not ready to merge, Linux build is currently failing:

```
[+] Building 17.3s (9/10)                                                                                                                                                                                                                                                                     docker:desktop-linux
 => [internal] load .dockerignore                                                                                                                                                                                                                                                                             0.0s
 => => transferring context: 272B                                                                                                                                                                                                                                                                             0.0s
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                                                                          0.0s
 => => transferring dockerfile: 655B                                                                                                                                                                                                                                                                          0.0s
 => [internal] load metadata for docker.io/library/alpine:3.19.0                                                                                                                                                                                                                                              0.0s
 => CACHED [build 1/5] FROM docker.io/library/alpine:3.19.0                                                                                                                                                                                                                                                   0.0s
 => [internal] load build context                                                                                                                                                                                                                                                                             2.4s
 => => transferring context: 1.50MB                                                                                                                                                                                                                                                                           2.4s
 => [build 2/5] RUN apk update --quiet && apk add --quiet --no-cache alpine-sdk make openjdk11 python3 py3-distutils-extra                                                                                                                                                                                   12.2s
 => [build 3/5] WORKDIR /java-tree-sitter                                                                                                                                                                                                                                                                     0.0s
 => [build 4/5] COPY . ./                                                                                                                                                                                                                                                                                     4.6s
 => ERROR [build 5/5] RUN python3 build.py --verbose                                                                                                                                                                                                                                                          0.3s
------                                                                                                                                                                                                                                                                                                             
 > [build 5/5] RUN python3 build.py --verbose:                                                                                                                                                                                                                                                                     
0.265 /java-tree-sitter/build.py:5: DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
0.265   from distutils.ccompiler import new_compiler as new_c_compiler
0.274 make: Entering directory '/java-tree-sitter/tree-sitter'
0.277 rm -f lib/src/*.o libtree-sitter.a libtree-sitter.so libtree-sitter.so.0 libtree-sitter.so.0.0
0.278 make: Leaving directory '/java-tree-sitter/tree-sitter'
0.279 make: Entering directory '/java-tree-sitter/tree-sitter'
0.282 cc -O3 -Wall -Wextra -Werror -std=gnu99 -fPIC -Ilib/src -Ilib/include   -c -o lib/src/alloc.o lib/src/alloc.c
0.291 cc: fatal error: cannot execute 'cc1': execvp: No such file or directory
0.291 compilation terminated.
0.292 make: *** [<builtin>: lib/src/alloc.o] Error 1
0.292 make: Leaving directory '/java-tree-sitter/tree-sitter'
0.292 Traceback (most recent call last):
0.292   File "/java-tree-sitter/build.py", line 174, in <module>
0.293     build(args.repositories, args.output, args.system, args.arch, args.verbose)
0.293   File "/java-tree-sitter/build.py", line 51, in build
0.293     raise RuntimeError("Failed to build tree-sitter library.")
0.293 RuntimeError: Failed to build tree-sitter library.
------
Dockerfile:20
--------------------
  18 |     COPY . ./
  19 |     
  20 | >>> RUN python3 build.py --verbose
  21 |     
  22 |     FROM scratch AS export
--------------------
ERROR: failed to solve: process "/bin/sh -c python3 build.py --verbose" did not complete successfully: exit code: 1
```