### PR TITLE
Add new methods for determining current and next `Node` parse state

### DIFF
--- a/lib/ch_usi_si_seart_treesitter_Node.cc
+++ b/lib/ch_usi_si_seart_treesitter_Node.cc
@@ -197,6 +197,12 @@ JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getFirstChildForB
   return childObject;
 }
 
+JNIEXPORT jint JNICALL Java_ch_usi_si_seart_treesitter_Node_getNextParseState(
+  JNIEnv* env, jobject thisObject) {
+  TSNode node = __unmarshalNode(env, thisObject);
+  return ts_node_is_null(node) ? (jint)-1 : (jint)ts_node_next_parse_state(node);
+}
+
 JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getNextSibling(
   JNIEnv* env, jobject thisObject, jboolean named) {
   TSNode (*next_sibling_getter)(TSNode) = (bool)named
@@ -231,6 +237,12 @@ JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getParent(
   jobject parentObject = __marshalNode(env, parent);
   __copyTree(env, thisObject, parentObject);
   return parentObject;
+}
+
+JNIEXPORT jint JNICALL Java_ch_usi_si_seart_treesitter_Node_getParseState(
+  JNIEnv* env, jobject thisObject) {
+  TSNode node = __unmarshalNode(env, thisObject);
+  return ts_node_is_null(node) ? (jint)-1 : (jint)ts_node_parse_state(node);
 }
 
 JNIEXPORT jint JNICALL Java_ch_usi_si_seart_treesitter_Node_getStartByte(

--- a/lib/ch_usi_si_seart_treesitter_Node.h
+++ b/lib/ch_usi_si_seart_treesitter_Node.h
@@ -89,6 +89,14 @@ JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getFirstChildForB
 
 /*
  * Class:     ch_usi_si_seart_treesitter_Node
+ * Method:    getNextParseState
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_ch_usi_si_seart_treesitter_Node_getNextParseState
+  (JNIEnv *, jobject);
+
+/*
+ * Class:     ch_usi_si_seart_treesitter_Node
  * Method:    getNextSibling
  * Signature: (Z)Lch/usi/si/seart/treesitter/Node;
  */
@@ -109,6 +117,14 @@ JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getPrevSibling
  * Signature: ()Lch/usi/si/seart/treesitter/Node;
  */
 JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getParent
+  (JNIEnv *, jobject);
+
+/*
+ * Class:     ch_usi_si_seart_treesitter_Node
+ * Method:    getParseState
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_ch_usi_si_seart_treesitter_Node_getParseState
   (JNIEnv *, jobject);
 
 /*

--- a/src/main/java/ch/usi/si/seart/treesitter/Node.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Node.java
@@ -283,6 +283,14 @@ public class Node implements Iterable<Node> {
     }
 
     /**
+     * Get the parse state after this {@code Node}.
+     *
+     * @return the next parse state
+     * @since 1.11.0
+     */
+    public native int getNextParseState();
+
+    /**
      * Get the next sibling {@code Node}.
      *
      * @return the next sibling, {@code null} if there is none
@@ -319,6 +327,14 @@ public class Node implements Iterable<Node> {
      * @return the parent, {@code null} if there is none
      */
     public native Node getParent();
+
+    /**
+     * Get the parse state of this {@code Node}.
+     *
+     * @return the parse state
+     * @since 1.11.0
+     */
+    public native int getParseState();
 
     /**
      * Get the node's {@link Range}, indicating its byte and row-column position span.

--- a/src/main/java/ch/usi/si/seart/treesitter/OffsetTreeCursor.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/OffsetTreeCursor.java
@@ -221,6 +221,11 @@ public class OffsetTreeCursor extends TreeCursor.Stub {
         }
 
         @Override
+        public int getNextParseState() {
+            return node.getNextParseState();
+        }
+
+        @Override
         public Node getNextSibling() {
             return new OffsetNode(node.getNextSibling());
         }
@@ -238,6 +243,11 @@ public class OffsetTreeCursor extends TreeCursor.Stub {
         @Override
         public Node getParent() {
             return new OffsetNode(node.getParent());
+        }
+
+        @Override
+        public int getParseState() {
+            return node.getParseState();
         }
 
         @Override

--- a/src/test/java/ch/usi/si/seart/treesitter/NodeTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/NodeTest.java
@@ -297,6 +297,12 @@ class NodeTest extends TestBase {
     }
 
     @Test
+    void testGetNextParseState() {
+        Assertions.assertEquals(0, root.getNextParseState());
+        Assertions.assertEquals(-1, new Node.Null().getNextParseState());
+    }
+
+    @Test
     void testGetNextNamedSibling() {
         Node function = root.getChild(0);
         Node def = function.getChild(0);
@@ -318,6 +324,12 @@ class NodeTest extends TestBase {
     void testGetParent() {
         Assertions.assertNull(root.getParent());
         Assertions.assertEquals(root, root.getChild(0).getParent());
+    }
+
+    @Test
+    void testGetParseState() {
+        Assertions.assertEquals(0, root.getParseState());
+        Assertions.assertEquals(-1, new Node.Null().getParseState());
     }
 
     @Test


### PR DESCRIPTION
Includes two new methods:
- `getNextParseState`
- `getParseState`