### PR TITLE
Add new method for determining if `Node` is an `ERROR`

### DIFF
--- a/lib/ch_usi_si_seart_treesitter_Node.cc
+++ b/lib/ch_usi_si_seart_treesitter_Node.cc
@@ -303,6 +303,12 @@ JNIEXPORT jboolean JNICALL Java_ch_usi_si_seart_treesitter_Node_hasError(
   return ts_node_has_error(node) ? JNI_TRUE : JNI_FALSE;
 }
 
+JNIEXPORT jboolean JNICALL Java_ch_usi_si_seart_treesitter_Node_isError(
+  JNIEnv* env, jobject thisObject) {
+  TSNode node = __unmarshalNode(env, thisObject);
+  return ts_node_is_error(node) ? JNI_TRUE : JNI_FALSE;
+}
+
 JNIEXPORT jboolean JNICALL Java_ch_usi_si_seart_treesitter_Node_isExtra(
   JNIEnv* env, jobject thisObject) {
   TSNode node = __unmarshalNode(env, thisObject);

--- a/lib/ch_usi_si_seart_treesitter_Node.h
+++ b/lib/ch_usi_si_seart_treesitter_Node.h
@@ -177,6 +177,14 @@ JNIEXPORT jboolean JNICALL Java_ch_usi_si_seart_treesitter_Node_hasError
 
 /*
  * Class:     ch_usi_si_seart_treesitter_Node
+ * Method:    isError
+ * Signature: ()Z
+ */
+JNIEXPORT jboolean JNICALL Java_ch_usi_si_seart_treesitter_Node_isError
+  (JNIEnv *, jobject);
+
+/*
+ * Class:     ch_usi_si_seart_treesitter_Node
  * Method:    isExtra
  * Signature: ()Z
  */

--- a/src/main/java/ch/usi/si/seart/treesitter/Node.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Node.java
@@ -395,6 +395,17 @@ public class Node implements Iterable<Node> {
     public native boolean hasError();
 
     /**
+     * Check if this node represents a syntax error.
+     * Syntax errors represent parts of the code that
+     * could not be incorporated into a valid syntax tree.
+     *
+     * @return {@code true} if the node is an {@code ERROR},
+     * {@code false} otherwise
+     * @since 1.11.0
+     */
+    public native boolean isError();
+
+    /**
      * Check if the node is an <em>extra</em>.
      * Extra nodes represent things like comments,
      * which are not required by the grammar,

--- a/src/main/java/ch/usi/si/seart/treesitter/OffsetTreeCursor.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/OffsetTreeCursor.java
@@ -286,6 +286,11 @@ public class OffsetTreeCursor extends TreeCursor.Stub {
         }
 
         @Override
+        public boolean isError() {
+            return node.isError();
+        }
+
+        @Override
         public boolean isExtra() {
             return node.isExtra();
         }

--- a/src/test/java/ch/usi/si/seart/treesitter/NodeTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/NodeTest.java
@@ -401,6 +401,19 @@ class NodeTest extends TestBase {
     }
 
     @Test
+    void testIsError() {
+        @Cleanup Tree tree = parser.parse("def foo(bar baz):\n  pass");
+        Node root = tree.getRootNode();
+        Node function = root.getChild(0);
+        Node parameters = function.getChildByFieldName("parameters");
+        Assertions.assertFalse(root.isError());
+        Assertions.assertFalse(function.isError());
+        Assertions.assertFalse(parameters.getChild(0).isError());
+        Assertions.assertFalse(parameters.getChild(1).isError());
+        Assertions.assertTrue(parameters.getChild(2).isError());
+    }
+
+    @Test
     void testIsExtra() {
         @Cleanup Tree tree = parser.parse("# this is just a comment");
         Node root = tree.getRootNode();


### PR DESCRIPTION
This new method `isError`, is complementary to `hasError`. The only difference is that it only checks if the current `Node` is the `ERROR`, whereas the other can determine if a `Node` has such descendants.