### PR TITLE
Add new method for getting the current relative depth of a `TreeCursor`

### DIFF
--- a/lib/ch_usi_si_seart_treesitter_TreeCursor.cc
+++ b/lib/ch_usi_si_seart_treesitter_TreeCursor.cc
@@ -11,6 +11,12 @@ JNIEXPORT void JNICALL Java_ch_usi_si_seart_treesitter_TreeCursor_delete(
   __clearPointer(env, thisObject);
 }
 
+JNIEXPORT jint JNICALL Java_ch_usi_si_seart_treesitter_TreeCursor_getCurrentDepth(
+  JNIEnv* env, jobject thisObject) {
+  TSTreeCursor* treeCursor = (TSTreeCursor*)__getPointer(env, thisObject);
+  return (jint)ts_tree_cursor_current_depth(treeCursor);
+}
+
 JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_TreeCursor_getCurrentNode(
   JNIEnv* env, jobject thisObject) {
   TSTreeCursor* cursor = (TSTreeCursor*)__getPointer(env, thisObject);

--- a/lib/ch_usi_si_seart_treesitter_TreeCursor.h
+++ b/lib/ch_usi_si_seart_treesitter_TreeCursor.h
@@ -17,6 +17,14 @@ JNIEXPORT void JNICALL Java_ch_usi_si_seart_treesitter_TreeCursor_delete
 
 /*
  * Class:     ch_usi_si_seart_treesitter_TreeCursor
+ * Method:    getCurrentDepth
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_ch_usi_si_seart_treesitter_TreeCursor_getCurrentDepth
+  (JNIEnv *, jobject);
+
+/*
+ * Class:     ch_usi_si_seart_treesitter_TreeCursor
  * Method:    getCurrentNode
  * Signature: ()Lch/usi/si/seart/treesitter/Node;
  */

--- a/src/main/java/ch/usi/si/seart/treesitter/OffsetTreeCursor.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/OffsetTreeCursor.java
@@ -55,6 +55,11 @@ public class OffsetTreeCursor extends TreeCursor.Stub {
     }
 
     @Override
+    public int getCurrentDepth() {
+        return cursor.getCurrentDepth();
+    }
+
+    @Override
     public String getCurrentFieldName() {
         return cursor.getCurrentFieldName();
     }

--- a/src/main/java/ch/usi/si/seart/treesitter/TreeCursor.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/TreeCursor.java
@@ -44,6 +44,15 @@ public class TreeCursor extends External implements Cloneable {
     protected native void delete();
 
     /**
+     * Get the depth of the cursor's current {@link Node} relative
+     * to the original {@link Node} that the cursor was constructed from.
+     *
+     * @return the relative depth of the tree cursor's current node
+     * @since 1.11.0
+     */
+    public native int getCurrentDepth();
+
+    /**
      * Get the {@link Node} that the cursor is currently pointing to.
      *
      * @return the tree cursor's current node
@@ -159,6 +168,11 @@ public class TreeCursor extends External implements Cloneable {
     public native TreeCursor clone();
 
     static class Stub extends TreeCursor {
+
+        @Override
+        public int getCurrentDepth() {
+            throw new UnsupportedOperationException();
+        }
 
         @Override
         public Node getCurrentNode() {

--- a/src/main/java/ch/usi/si/seart/treesitter/printer/SyntaxTreePrinter.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/printer/SyntaxTreePrinter.java
@@ -31,27 +31,18 @@ public class SyntaxTreePrinter extends IterativeTreePrinter {
     }
 
     protected void write(Consumer<String> appender) {
-        int depth = 0;
         for (;;) {
             TreeCursorNode cursorNode = cursor.getCurrentTreeCursorNode();
             if (cursorNode.isNamed()) {
+                int depth = cursor.getCurrentDepth();
                 String indent = "  ".repeat(depth);
                 appender.accept(indent);
                 appender.accept(cursorNode.toString());
                 appender.accept("\n");
             }
-            if (cursor.gotoFirstChild()) {
-                depth++;
-                continue;
-            } else if (cursor.gotoNextSibling()) {
-                continue;
-            }
+            if (cursor.gotoFirstChild() || cursor.gotoNextSibling()) continue;
             do {
-                if (cursor.gotoParent()) {
-                    depth--;
-                } else {
-                    return;
-                }
+                if (!cursor.gotoParent()) return;
             } while (!cursor.gotoNextSibling());
         }
     }

--- a/src/test/java/ch/usi/si/seart/treesitter/TreeCursorTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/TreeCursorTest.java
@@ -70,6 +70,21 @@ class TreeCursorTest extends TestBase {
     }
 
     @Test
+    void testGetCurrentDepth() {
+        Assertions.assertEquals(0, cursor.getCurrentDepth());
+        cursor.gotoFirstChild();
+        Assertions.assertEquals(1, cursor.getCurrentDepth());
+        cursor.gotoFirstChild();
+        Assertions.assertEquals(2, cursor.getCurrentDepth());
+        cursor.gotoNextSibling();
+        Assertions.assertEquals(2, cursor.getCurrentDepth());
+        cursor.gotoParent();
+        Assertions.assertEquals(1, cursor.getCurrentDepth());
+        cursor.gotoParent();
+        Assertions.assertEquals(0, cursor.getCurrentDepth());
+    }
+
+    @Test
     void testGotoFirstChildByteOffset() {
         cursor.gotoFirstChild(); // function_definition
         cursor.gotoFirstChild(4);


### PR DESCRIPTION
Retrieves the depth relative to the starting `Node`. Will see most use in the `Tree` printers.