### PR TITLE
Add new method for resetting a `TreeCursor` state to that of another one

### DIFF
--- a/lib/ch_usi_si_seart_treesitter_TreeCursor.cc
+++ b/lib/ch_usi_si_seart_treesitter_TreeCursor.cc
@@ -156,6 +156,31 @@ JNIEXPORT jboolean JNICALL Java_ch_usi_si_seart_treesitter_TreeCursor_gotoNode(
   return JNI_TRUE;
 }
 
+JNIEXPORT jboolean JNICALL Java_ch_usi_si_seart_treesitter_TreeCursor_reset(
+  JNIEnv* env, jobject thisObject, jobject otherObject) {
+  if (otherObject == NULL) {
+    __throwNPE(env, "Cursor must not be null!");
+    return JNI_FALSE;
+  }
+  jobject thisTreeObject = env->GetObjectField(thisObject, _treeCursorTreeField);
+  jobject otherTreeObject = env->GetObjectField(otherObject, _treeCursorTreeField);
+  TSTree* thisTree = (TSTree*)__getPointer(env, thisTreeObject);
+  TSTree* otherTree = (TSTree*)__getPointer(env, otherTreeObject);
+  if (thisTree != otherTree) {
+    __throwIAE(env, "Cursor must be from the same tree!");
+    return JNI_FALSE;
+  }
+  TSTreeCursor* thisCursor = (TSTreeCursor*)__getPointer(env, thisObject);
+  TSTreeCursor* otherCursor = (TSTreeCursor*)__getPointer(env, otherObject);
+  TSNode thisNode = ts_tree_cursor_current_node(thisCursor);
+  TSNode otherNode = ts_tree_cursor_current_node(otherCursor);
+  if (ts_node_eq(thisNode, otherNode)) return JNI_FALSE;
+  ts_tree_cursor_reset_to(otherCursor, thisCursor);
+  env->SetIntField(thisObject, _treeCursorContext0Field, thisCursor->context[0]);
+  env->SetIntField(thisObject, _treeCursorContext1Field, thisCursor->context[1]);
+  return JNI_TRUE;
+}
+
 JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_TreeCursor_clone(
   JNIEnv* env, jobject thisObject) {
   jobject treeObject = env->GetObjectField(thisObject, _treeCursorTreeField);

--- a/lib/ch_usi_si_seart_treesitter_TreeCursor.h
+++ b/lib/ch_usi_si_seart_treesitter_TreeCursor.h
@@ -97,6 +97,14 @@ JNIEXPORT jboolean JNICALL Java_ch_usi_si_seart_treesitter_TreeCursor_gotoNode
 
 /*
  * Class:     ch_usi_si_seart_treesitter_TreeCursor
+ * Method:    reset
+ * Signature: (Lch/usi/si/seart/treesitter/TreeCursor;)Z
+ */
+JNIEXPORT jboolean JNICALL Java_ch_usi_si_seart_treesitter_TreeCursor_reset
+  (JNIEnv *, jobject, jobject);
+
+/*
+ * Class:     ch_usi_si_seart_treesitter_TreeCursor
  * Method:    clone
  * Signature: ()Lch/usi/si/seart/treesitter/TreeCursor;
  */

--- a/src/main/java/ch/usi/si/seart/treesitter/OffsetTreeCursor.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/OffsetTreeCursor.java
@@ -100,6 +100,11 @@ public class OffsetTreeCursor extends TreeCursor.Stub {
     }
 
     @Override
+    public boolean reset(@NotNull TreeCursor other) {
+        return cursor.reset(other);
+    }
+
+    @Override
     public Node getCurrentNode() {
         return new OffsetNode(cursor.getCurrentNode());
     }

--- a/src/main/java/ch/usi/si/seart/treesitter/TreeCursor.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/TreeCursor.java
@@ -159,6 +159,18 @@ public class TreeCursor extends External implements Cloneable {
     }
 
     /**
+     * Reset the cursor to the same state as another cursor.
+     *
+     * @param other the cursor to copy state from
+     * @return true if the cursor successfully moved,
+     * and false if it was already located at the same node
+     * @throws NullPointerException if {@code other} is null
+     * @throws IllegalArgumentException if the other cursor is not from the same tree
+     * @since 1.11.0
+     */
+    public native boolean reset(@NotNull TreeCursor other);
+
+    /**
      * Clone this cursor, creating a separate, independent instance.
      *
      * @return a clone of this instance
@@ -221,6 +233,11 @@ public class TreeCursor extends External implements Cloneable {
 
         @Override
         public void preorderTraversal(@NotNull Consumer<Node> callback) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean reset(@NotNull TreeCursor other) {
             throw new UnsupportedOperationException();
         }
 

--- a/src/test/java/ch/usi/si/seart/treesitter/TreeCursorTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/TreeCursorTest.java
@@ -149,6 +149,23 @@ class TreeCursorTest extends TestBase {
     }
 
     @Test
+    void testReset() {
+        @Cleanup TreeCursor external = tree.clone().getRootNode().walk();
+        Node root = tree.getRootNode();
+        @Cleanup TreeCursor other = root.walk();
+        Assertions.assertEquals(cursor.getCurrentNode(), other.getCurrentNode());
+        Assertions.assertFalse(cursor.reset(other));
+        other.gotoFirstChild(); // function_definition
+        other.gotoFirstChild(); // def
+        other.gotoNextSibling(); // identifier
+        Assertions.assertNotEquals(cursor.getCurrentNode(), other.getCurrentNode());
+        Assertions.assertTrue(cursor.reset(other));
+        Assertions.assertEquals(cursor.getCurrentNode(), other.getCurrentNode());
+        Assertions.assertThrows(NullPointerException.class, () -> cursor.reset(null));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> cursor.reset(external));
+    }
+
+    @Test
     void testPreorderTraversal() {
         AtomicInteger count = new AtomicInteger();
         cursor.preorderTraversal(node -> {


### PR DESCRIPTION
This PR adds a new method: `TreeCursor#reset`