### PR TITLE
Add `Metadata` inner class for `Language` versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ pom.xml.releaseBackup
 pom.xml.versionsBackup
 pom.xml.next
 release.properties
+language.properties
 dependency-reduced-pom.xml
 buildNumber.properties
 .mvn/timing.properties

--- a/lib/ch_usi_si_seart_treesitter_Language.cc
+++ b/lib/ch_usi_si_seart_treesitter_Language.cc
@@ -184,7 +184,7 @@ JNIEXPORT jlong JNICALL Java_ch_usi_si_seart_treesitter_Language_go(
 #endif
 }
 
-JNIEXPORT jlong JNICALL Java_ch_usi_si_seart_treesitter_Language_graphQl(
+JNIEXPORT jlong JNICALL Java_ch_usi_si_seart_treesitter_Language_graphql(
   JNIEnv* env, jclass self) {
 #ifdef TS_LANGUAGE_GRAPHQL
   return (jlong)tree_sitter_graphql();

--- a/lib/ch_usi_si_seart_treesitter_Language.cc
+++ b/lib/ch_usi_si_seart_treesitter_Language.cc
@@ -49,7 +49,7 @@ JNIEXPORT jlong JNICALL Java_ch_usi_si_seart_treesitter_Language_clojure(
 #endif
 }
 
-JNIEXPORT jlong JNICALL Java_ch_usi_si_seart_treesitter_Language_cMake(
+JNIEXPORT jlong JNICALL Java_ch_usi_si_seart_treesitter_Language_cmake(
   JNIEnv* env, jclass self) {
 #ifdef TS_LANGUAGE_CMAKE
   return (jlong)tree_sitter_cmake();

--- a/lib/ch_usi_si_seart_treesitter_Language.h
+++ b/lib/ch_usi_si_seart_treesitter_Language.h
@@ -171,10 +171,10 @@ JNIEXPORT jlong JNICALL Java_ch_usi_si_seart_treesitter_Language_go
 
 /*
  * Class:     ch_usi_si_seart_treesitter_Language
- * Method:    graphQl
+ * Method:    graphql
  * Signature: ()J
  */
-JNIEXPORT jlong JNICALL Java_ch_usi_si_seart_treesitter_Language_graphQl
+JNIEXPORT jlong JNICALL Java_ch_usi_si_seart_treesitter_Language_graphql
   (JNIEnv *, jclass);
 
 /*

--- a/lib/ch_usi_si_seart_treesitter_Language.h
+++ b/lib/ch_usi_si_seart_treesitter_Language.h
@@ -51,10 +51,10 @@ JNIEXPORT jlong JNICALL Java_ch_usi_si_seart_treesitter_Language_commonLisp
 
 /*
  * Class:     ch_usi_si_seart_treesitter_Language
- * Method:    cMake
+ * Method:    cmake
  * Signature: ()J
  */
-JNIEXPORT jlong JNICALL Java_ch_usi_si_seart_treesitter_Language_cMake
+JNIEXPORT jlong JNICALL Java_ch_usi_si_seart_treesitter_Language_cmake
   (JNIEnv *, jclass);
 
 /*

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,7 @@
   </distributionManagement>
 
   <properties>
+    <project.build.resourceDirectory>${project.basedir}/src/main/resources</project.build.resourceDirectory>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>11</java.version>
   </properties>
@@ -138,7 +139,7 @@
   <build>
     <resources>
       <resource>
-        <directory>${project.basedir}/src/main/resources</directory>
+        <directory>${project.build.resourceDirectory}</directory>
         <excludes>
           <exclude>**/.keep</exclude>
         </excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -393,6 +393,22 @@
             </configuration>
           </execution>
           <execution>
+            <id>generate-language-metadata-file</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <configuration>
+              <executable>python3</executable>
+              <workingDirectory>${project.basedir}</workingDirectory>
+              <arguments>
+                <argument>properties.py</argument>
+                <argument>-o</argument>
+                <argument>${project.build.resourceDirectory}/language.properties</argument>
+              </arguments>
+            </configuration>
+          </execution>
+          <execution>
             <id>build-shared-object-library-macos</id>
             <phase>compile</phase>
             <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -136,6 +136,14 @@
   </dependencies>
 
   <build>
+    <resources>
+      <resource>
+        <directory>${project.basedir}/src/main/resources</directory>
+        <excludes>
+          <exclude>**/.keep</exclude>
+        </excludes>
+      </resource>
+    </resources>
     <plugins>
       <plugin>
         <artifactId>maven-clean-plugin</artifactId>

--- a/properties.py
+++ b/properties.py
@@ -3,7 +3,6 @@
 from argparse import ArgumentParser
 from glob import glob as find
 from os import getcwd as cwd
-from os import makedirs
 from os.path import basename, dirname, realpath
 from os.path import join as path
 from subprocess import run
@@ -41,7 +40,6 @@ if __name__ == "__main__":
     args = parser.parse_args()
     path = args.output
     directories = find(f"{__location__}/tree-sitter-*")
-    makedirs(dirname(path), exist_ok=True)
     with open(path, "w") as f:
         for directory in sorted(directories):
             PropertyWriter(directory).write(f)

--- a/properties.py
+++ b/properties.py
@@ -26,7 +26,7 @@ class PropertyWriter:
         for key, cmd in self.commands.items():
             result = run(["git", *cmd], cwd=self.workdir, capture_output=True, text=True)
             value = "" if result.returncode else result.stdout.strip()
-            outfile.write(f"tree-sitter.language.{self.language}.{key}={value}\n")
+            outfile.write(f"{key}.{self.language}={value}\n")
 
 
 if __name__ == "__main__":

--- a/properties.py
+++ b/properties.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+
+from argparse import ArgumentParser
+from glob import glob as find
+from os import getcwd as cwd
+from os import makedirs
+from os.path import basename, dirname, realpath
+from os.path import join as path
+from subprocess import run
+
+__location__ = realpath(path(cwd(), dirname(__file__)))
+
+
+class PropertyWriter:
+
+    commands = {
+        "url": ["config", "--get", "remote.origin.url"],
+        "sha": ["rev-parse", "HEAD"],
+        "tag": ["describe", "--tags", "--abbrev=0"],
+    }
+
+    def __init__(self, workdir):
+        self.workdir = workdir
+        self.language = basename(workdir)[12:]
+
+    def write(self, outfile):
+        for key, cmd in self.commands.items():
+            result = run(["git", *cmd], cwd=self.workdir, capture_output=True, text=True)
+            value = "" if result.returncode else result.stdout.strip()
+            outfile.write(f"tree-sitter.language.{self.language}.{key}={value}\n")
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser(description="Generate tree-sitter properties file.")
+    parser.add_argument(
+        "-o",
+        "--output",
+        default=f"{__location__}/language.properties",
+        help="Output file path.",
+    )
+    args = parser.parse_args()
+    path = args.output
+    directories = find(f"{__location__}/tree-sitter-*")
+    makedirs(dirname(path), exist_ok=True)
+    with open(path, "w") as f:
+        for directory in sorted(directories):
+            PropertyWriter(directory).write(f)

--- a/src/main/java/ch/usi/si/seart/treesitter/Language.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Language.java
@@ -681,4 +681,8 @@ public enum Language {
     private static String capitalize(String name) {
         return name.charAt(0) + name.substring(1).toLowerCase();
     }
+
+    private String getSubmoduleName() {
+        return name().toLowerCase().replace("_", "-");
+    }
 }

--- a/src/main/java/ch/usi/si/seart/treesitter/Language.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Language.java
@@ -2,6 +2,7 @@ package ch.usi.si.seart.treesitter;
 
 import ch.usi.si.seart.treesitter.error.ABIVersionError;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Generated;
 import lombok.Getter;
 import lombok.experimental.FieldDefaults;
@@ -10,6 +11,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.TestOnly;
 
 import java.io.InputStream;
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
@@ -697,5 +699,39 @@ public enum Language {
 
     private String getSubmoduleName() {
         return name().toLowerCase().replace("_", "-");
+    }
+
+    /**
+     * Represents Git metadata related to the grammar submodule that a language was built from.
+     * It is intended as a more fine-grained alternative to the {@link #getVersion()} method.
+     * Since community-developed grammars tend to veer from guidelines imposed by the original developers,
+     * the ABI version can not be used to reliably track the current iteration of the grammar.
+     * It is worth noting that some metadata (like tags) may not be present for all languages.
+     *
+     * @author Ozren Dabić
+     * @since 1.11.0
+     */
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+    public static final class Metadata {
+
+        URL url;
+        String sha;
+        String tag;
+
+        @Generated
+        public URL getURL() {
+            return url;
+        }
+
+        @Generated
+        public String getSHA() {
+            return sha;
+        }
+
+        @Generated
+        public String getTag() {
+            return tag;
+        }
     }
 }

--- a/src/main/java/ch/usi/si/seart/treesitter/Language.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Language.java
@@ -9,6 +9,7 @@ import org.apache.commons.io.FilenameUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.TestOnly;
 
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
@@ -17,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Properties;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -550,6 +552,17 @@ public enum Language {
     List<String> extensions;
 
     private static final long INVALID = 0L;
+
+    private static final Properties PROPERTIES = new Properties();
+
+    static {
+        ClassLoader loader = Language.class.getClassLoader();
+        try (InputStream stream = loader.getResourceAsStream("language.properties")) {
+            PROPERTIES.load(stream);
+        } catch (Exception ex) {
+            throw new ExceptionInInitializerError(ex);
+        }
+    }
 
     private static final Map<String, List<Language>> EXTENSION_LOOKUP = Stream.of(Language.values())
             .flatMap(language -> language.getExtensions().stream().map(extension -> Map.entry(extension, language)))

--- a/src/main/java/ch/usi/si/seart/treesitter/Language.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Language.java
@@ -78,7 +78,7 @@ public enum Language {
      *
      * @see <a href="https://github.com/uyha/tree-sitter-cmake">tree-sitter-cmake</a>
      */
-    CMAKE(cMake(), "cmake"),
+    CMAKE(cmake(), "cmake"),
 
     /**
      * Common Lisp programming language.
@@ -442,7 +442,7 @@ public enum Language {
     private static native long c();
     private static native long clojure();
     private static native long commonLisp();
-    private static native long cMake();
+    private static native long cmake();
     private static native long cSharp();
     private static native long cpp();
     private static native long css();

--- a/src/main/java/ch/usi/si/seart/treesitter/Language.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Language.java
@@ -561,6 +561,7 @@ public enum Language {
         ClassLoader loader = Language.class.getClassLoader();
         try (InputStream stream = loader.getResourceAsStream("language.properties")) {
             PROPERTIES.load(stream);
+            PROPERTIES.entrySet().removeIf(entry -> entry.getValue().toString().isEmpty());
         } catch (Exception ex) {
             throw new ExceptionInInitializerError(ex);
         }

--- a/src/main/java/ch/usi/si/seart/treesitter/Language.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Language.java
@@ -190,7 +190,7 @@ public enum Language {
      *
      * @see <a href="https://github.com/bkegley/tree-sitter-graphql">tree-sitter-graphql</a>
      */
-    GRAPHQL(graphQl(), "graphql"),
+    GRAPHQL(graphql(), "graphql"),
 
     /**
      * HCL: HashiCorp Configuration Language.
@@ -457,7 +457,7 @@ public enum Language {
     private static native long gitattributes();
     private static native long gitignore();
     private static native long go();
-    private static native long graphQl();
+    private static native long graphql();
     private static native long haskell();
     private static native long hcl();
     private static native long html();

--- a/src/main/java/ch/usi/si/seart/treesitter/Language.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Language.java
@@ -11,6 +11,8 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.TestOnly;
 
 import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -696,6 +698,37 @@ public enum Language {
 
     private static String capitalize(String name) {
         return name.charAt(0) + name.substring(1).toLowerCase();
+    }
+
+    /**
+     * Get the Git metadata for the language.
+     *
+     * @return the language metadata
+     * @since 1.11.0
+     */
+    public Metadata getMetadata() {
+        return new Metadata(getURL(), getSHA(), getTag());
+    }
+
+    private URL getURL() {
+        String key = "url." + getSubmoduleName();
+        String value = PROPERTIES.getProperty(key);
+        if (value == null) return null;
+        try {
+            return new URL(value);
+        } catch (MalformedURLException ex) {
+            throw new UncheckedIOException(ex);
+        }
+    }
+
+    private String getSHA() {
+        String key = "sha." + getSubmoduleName();
+        return PROPERTIES.getProperty(key);
+    }
+
+    private String getTag() {
+        String key = "tag." + getSubmoduleName();
+        return PROPERTIES.getProperty(key);
     }
 
     private String getSubmoduleName() {

--- a/src/main/java/ch/usi/si/seart/treesitter/Language.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Language.java
@@ -92,7 +92,7 @@ public enum Language {
      *
      * @see <a href="https://github.com/tree-sitter/tree-sitter-c-sharp">tree-sitter-c-sharp</a>
      */
-    CSHARP(cSharp(), "cs"),
+    C_SHARP(cSharp(), "cs"),
 
     /**
      * C++ programming language.
@@ -661,8 +661,8 @@ public enum Language {
             /*
              * Special Cases
              */
+            case C_SHARP: return "C#";
             case CMAKE: return "CMake";
-            case CSHARP: return "C#";
             case CPP: return "C++";
             case GRAPHQL: return "GraphQL";
             case JAVASCRIPT: return "JavaScript";

--- a/src/main/java/ch/usi/si/seart/treesitter/Language.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Language.java
@@ -737,9 +737,9 @@ public enum Language {
 
     /**
      * Represents Git metadata related to the grammar submodule that a language was built from.
-     * It is intended as a more fine-grained alternative to the {@link #getVersion()} method.
+     * It is intended as a more fine-grained alternative to the ABI {@link Language#version}.
      * Since community-developed grammars tend to veer from guidelines imposed by the original developers,
-     * the ABI version can not be used to reliably track the current iteration of the grammar.
+     * said version number can not be used to reliably track the current iteration of the grammar.
      * It is worth noting that some metadata (like tags) may not be present for all languages.
      *
      * @author Ozren Dabić


### PR DESCRIPTION
This PR introduces a new data class intended to give users a more accurate representation of the current grammar version at runtime. This is achieved through bundling the Git submodule information into a dedicated `.properties` file, which is then read at runtime.