### PR TITLE
Add "grammar" variants to some `Node` methods

### DIFF
--- a/lib/ch_usi_si_seart_treesitter_Node.cc
+++ b/lib/ch_usi_si_seart_treesitter_Node.cc
@@ -266,7 +266,7 @@ JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getStartPoint(
 }
 
 JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getSymbol(
-  JNIEnv* env, jobject thisObject) {
+  JNIEnv* env, jobject thisObject, jboolean grammar) {
   jobject treeObject = env->GetObjectField(thisObject, _nodeTreeField);
   if (treeObject == NULL) return NULL;
   jobject languageObject = env->GetObjectField(treeObject, _treeLanguageField);
@@ -277,7 +277,10 @@ JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getSymbol(
   const TSLanguage* language = (const TSLanguage*)languageId;
   TSNode node = __unmarshalNode(env, thisObject);
   if (ts_node_is_null(node)) return NULL;
-  TSSymbol symbol = ts_node_symbol(node);
+  TSSymbol (*symbol_getter)(TSNode) = (bool)grammar
+    ? ts_node_grammar_symbol
+    : ts_node_symbol;
+  TSSymbol symbol = symbol_getter(node);
   const char* name = ts_language_symbol_name(language, symbol);
   TSSymbolType type = ts_language_symbol_type(language, symbol);
   return env->NewObject(

--- a/lib/ch_usi_si_seart_treesitter_Node.cc
+++ b/lib/ch_usi_si_seart_treesitter_Node.cc
@@ -293,10 +293,13 @@ JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getSymbol(
 }
 
 JNIEXPORT jstring JNICALL Java_ch_usi_si_seart_treesitter_Node_getType(
-  JNIEnv* env, jobject thisObject) {
+  JNIEnv* env, jobject thisObject, jboolean grammar) {
   TSNode node = __unmarshalNode(env, thisObject);
   if (ts_node_is_null(node)) return NULL;
-  const char* type = ts_node_type(node);
+  const char* (*type_getter)(TSNode) = (bool)grammar
+    ? ts_node_grammar_type
+    : ts_node_type;
+  const char* type = type_getter(node);
   return env->NewStringUTF(type);
 }
 

--- a/lib/ch_usi_si_seart_treesitter_Node.h
+++ b/lib/ch_usi_si_seart_treesitter_Node.h
@@ -162,10 +162,10 @@ JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getSymbol
 /*
  * Class:     ch_usi_si_seart_treesitter_Node
  * Method:    getType
- * Signature: ()Ljava/lang/String;
+ * Signature: (Z)Ljava/lang/String;
  */
 JNIEXPORT jstring JNICALL Java_ch_usi_si_seart_treesitter_Node_getType
-  (JNIEnv *, jobject);
+  (JNIEnv *, jobject, jboolean);
 
 /*
  * Class:     ch_usi_si_seart_treesitter_Node

--- a/lib/ch_usi_si_seart_treesitter_Node.h
+++ b/lib/ch_usi_si_seart_treesitter_Node.h
@@ -154,10 +154,10 @@ JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getStartPoint
 /*
  * Class:     ch_usi_si_seart_treesitter_Node
  * Method:    getSymbol
- * Signature: ()Lch/usi/si/seart/treesitter/Symbol;
+ * Signature: (Z)Lch/usi/si/seart/treesitter/Symbol;
  */
 JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getSymbol
-  (JNIEnv *, jobject);
+  (JNIEnv *, jobject, jboolean);
 
 /*
  * Class:     ch_usi_si_seart_treesitter_Node

--- a/src/main/java/ch/usi/si/seart/treesitter/Node.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Node.java
@@ -186,6 +186,16 @@ public class Node implements Iterable<Node> {
     }
 
     /**
+     * Get the node's type as a string as it appears in the grammar, ignoring aliases.
+     *
+     * @return the node's type
+     * @since 1.12.0
+     */
+    public String getGrammarType() {
+        return getType(true);
+    }
+
+    /**
      * Get the first child {@code Node} that extends beyond the given byte offset.
      *
      * @param offset the offset in bytes
@@ -396,7 +406,11 @@ public class Node implements Iterable<Node> {
      *
      * @return the node's type
      */
-    public native String getType();
+    public String getType() {
+        return getType(false);
+    }
+
+    private native String getType(boolean grammar);
 
     /**
      * Check if this node, or any of its children, has been edited.

--- a/src/main/java/ch/usi/si/seart/treesitter/Node.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Node.java
@@ -173,6 +173,18 @@ public class Node implements Iterable<Node> {
      */
     public native String getFieldNameForChild(int child);
 
+
+    /**
+     * Get the syntax tree {@link Symbol} associated with this node
+     * as it appears in the grammar, ignoring aliases.
+     *
+     * @return the node's symbol
+     * @since 1.12.0
+     */
+    public Symbol getGrammarSymbol() {
+        return getSymbol(true);
+    }
+
     /**
      * Get the first child {@code Node} that extends beyond the given byte offset.
      *
@@ -373,7 +385,11 @@ public class Node implements Iterable<Node> {
      * @return the node's symbol
      * @since 1.6.0
      */
-    public native Symbol getSymbol();
+    public Symbol getSymbol() {
+        return getSymbol(false);
+    }
+
+    private native Symbol getSymbol(boolean grammar);
 
     /**
      * Get the node's type as a string.

--- a/src/main/java/ch/usi/si/seart/treesitter/OffsetTreeCursor.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/OffsetTreeCursor.java
@@ -191,6 +191,11 @@ public class OffsetTreeCursor extends TreeCursor.Stub {
         }
 
         @Override
+        public String getGrammarType() {
+            return node.getGrammarType();
+        }
+
+        @Override
         public Node getFirstChildForByte(int offset) {
             throw new UnsupportedOperationException(UOE_MESSAGE_2);
         }

--- a/src/main/java/ch/usi/si/seart/treesitter/OffsetTreeCursor.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/OffsetTreeCursor.java
@@ -186,6 +186,11 @@ public class OffsetTreeCursor extends TreeCursor.Stub {
         }
 
         @Override
+        public Symbol getGrammarSymbol() {
+            return node.getGrammarSymbol();
+        }
+
+        @Override
         public Node getFirstChildForByte(int offset) {
             throw new UnsupportedOperationException(UOE_MESSAGE_2);
         }

--- a/src/test/java/ch/usi/si/seart/treesitter/NodeTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/NodeTest.java
@@ -398,6 +398,13 @@ class NodeTest extends TestBase {
     }
 
     @Test
+    void testGetGrammarType() {
+        Assertions.assertEquals("module", root.getGrammarType());
+        Assertions.assertEquals("function_definition", root.getChild(0).getGrammarType());
+        Assertions.assertNull(empty.getGrammarType());
+    }
+
+    @Test
     void testHasError() {
         @Cleanup Tree tree = parser.parse("def foo(bar, baz):\n  print(bar.)");
         Node root = tree.getRootNode();

--- a/src/test/java/ch/usi/si/seart/treesitter/NodeTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/NodeTest.java
@@ -383,6 +383,14 @@ class NodeTest extends TestBase {
     }
 
     @Test
+    void testGetGrammarSymbol() {
+        Symbol symbol = root.getGrammarSymbol();
+        Assertions.assertEquals("module", symbol.getName());
+        Assertions.assertEquals(Symbol.Type.REGULAR, symbol.getType());
+        Assertions.assertNull(empty.getGrammarSymbol());
+    }
+
+    @Test
     void testGetType() {
         Assertions.assertEquals("module", root.getType());
         Assertions.assertEquals("function_definition", root.getChild(0).getType());


### PR DESCRIPTION
This introduces two new methods:

- `getGrammarType`
- `getGrammarSymbol`

Which are variants of `getType` and `getSymbol` respectively. They have the same functionality and share the underlying native code, with the only difference being that the new methods return the type/symbol as it appears in the grammar, ignoring any aliases.