### PR TITLE
Add new traversal variants to `TreeCursor`

### DIFF
--- a/lib/ch_usi_si_seart_treesitter_TreeCursor.cc
+++ b/lib/ch_usi_si_seart_treesitter_TreeCursor.cc
@@ -132,6 +132,15 @@ JNIEXPORT jboolean JNICALL Java_ch_usi_si_seart_treesitter_TreeCursor_gotoNextSi
   return result ? JNI_TRUE : JNI_FALSE;
 }
 
+JNIEXPORT jboolean JNICALL Java_ch_usi_si_seart_treesitter_TreeCursor_gotoPrevSibling(
+  JNIEnv* env, jobject thisObject) {
+  TSTreeCursor* cursor = (TSTreeCursor*)__getPointer(env, thisObject);
+  bool result = ts_tree_cursor_goto_previous_sibling(cursor);
+  env->SetIntField(thisObject, _treeCursorContext0Field, cursor->context[0]);
+  env->SetIntField(thisObject, _treeCursorContext1Field, cursor->context[1]);
+  return result ? JNI_TRUE : JNI_FALSE;
+}
+
 JNIEXPORT jboolean JNICALL Java_ch_usi_si_seart_treesitter_TreeCursor_gotoParent(
   JNIEnv* env, jobject thisObject) {
   TSTreeCursor* cursor = (TSTreeCursor*)__getPointer(env, thisObject);

--- a/lib/ch_usi_si_seart_treesitter_TreeCursor.cc
+++ b/lib/ch_usi_si_seart_treesitter_TreeCursor.cc
@@ -114,6 +114,15 @@ JNIEXPORT jboolean JNICALL Java_ch_usi_si_seart_treesitter_TreeCursor_gotoFirstC
   return (result > -1) ? JNI_TRUE : JNI_FALSE;
 }
 
+JNIEXPORT jboolean JNICALL Java_ch_usi_si_seart_treesitter_TreeCursor_gotoLastChild(
+  JNIEnv* env, jobject thisObject) {
+  TSTreeCursor* cursor = (TSTreeCursor*)__getPointer(env, thisObject);
+  bool result = ts_tree_cursor_goto_last_child(cursor);
+  env->SetIntField(thisObject, _treeCursorContext0Field, cursor->context[0]);
+  env->SetIntField(thisObject, _treeCursorContext1Field, cursor->context[1]);
+  return result ? JNI_TRUE : JNI_FALSE;
+}
+
 JNIEXPORT jboolean JNICALL Java_ch_usi_si_seart_treesitter_TreeCursor_gotoNextSibling(
   JNIEnv* env, jobject thisObject) {
   TSTreeCursor* cursor = (TSTreeCursor*)__getPointer(env, thisObject);

--- a/lib/ch_usi_si_seart_treesitter_TreeCursor.h
+++ b/lib/ch_usi_si_seart_treesitter_TreeCursor.h
@@ -89,6 +89,14 @@ JNIEXPORT jboolean JNICALL Java_ch_usi_si_seart_treesitter_TreeCursor_gotoNextSi
 
 /*
  * Class:     ch_usi_si_seart_treesitter_TreeCursor
+ * Method:    gotoPrevSibling
+ * Signature: ()Z
+ */
+JNIEXPORT jboolean JNICALL Java_ch_usi_si_seart_treesitter_TreeCursor_gotoPrevSibling
+  (JNIEnv *, jobject);
+
+/*
+ * Class:     ch_usi_si_seart_treesitter_TreeCursor
  * Method:    gotoParent
  * Signature: ()Z
  */

--- a/lib/ch_usi_si_seart_treesitter_TreeCursor.h
+++ b/lib/ch_usi_si_seart_treesitter_TreeCursor.h
@@ -73,6 +73,14 @@ JNIEXPORT jboolean JNICALL Java_ch_usi_si_seart_treesitter_TreeCursor_gotoFirstC
 
 /*
  * Class:     ch_usi_si_seart_treesitter_TreeCursor
+ * Method:    gotoLastChild
+ * Signature: ()Z
+ */
+JNIEXPORT jboolean JNICALL Java_ch_usi_si_seart_treesitter_TreeCursor_gotoLastChild
+  (JNIEnv *, jobject);
+
+/*
+ * Class:     ch_usi_si_seart_treesitter_TreeCursor
  * Method:    gotoNextSibling
  * Signature: ()Z
  */

--- a/src/main/java/ch/usi/si/seart/treesitter/OffsetTreeCursor.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/OffsetTreeCursor.java
@@ -80,6 +80,11 @@ public class OffsetTreeCursor extends TreeCursor.Stub {
     }
 
     @Override
+    public boolean gotoLastChild() {
+        return cursor.gotoLastChild();
+    }
+
+    @Override
     public boolean gotoNextSibling() {
         return cursor.gotoNextSibling();
     }

--- a/src/main/java/ch/usi/si/seart/treesitter/OffsetTreeCursor.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/OffsetTreeCursor.java
@@ -90,6 +90,11 @@ public class OffsetTreeCursor extends TreeCursor.Stub {
     }
 
     @Override
+    public boolean gotoPrevSibling() {
+        return cursor.gotoPrevSibling();
+    }
+
+    @Override
     public boolean gotoParent() {
         return cursor.gotoParent();
     }

--- a/src/main/java/ch/usi/si/seart/treesitter/TreeCursor.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/TreeCursor.java
@@ -112,6 +112,19 @@ public class TreeCursor extends External implements Cloneable {
     public native boolean gotoFirstChild(@NotNull Point point);
 
     /**
+     * Move the cursor to the last child of its current node.
+     * <p>
+     * Note that this method may be slower than {@link #gotoFirstChild()}
+     * because it needs to iterate through all the children to
+     * compute the child's position.
+     *
+     * @return true if the cursor successfully moved,
+     * and false if there were no children
+     * @since 1.12.0
+     */
+    public native boolean gotoLastChild();
+
+    /**
      * Move the cursor to the next sibling of its current node.
      *
      * @return true if the cursor successfully moved,
@@ -213,6 +226,11 @@ public class TreeCursor extends External implements Cloneable {
 
         @Override
         public boolean gotoFirstChild(@NotNull Point point) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean gotoLastChild() {
             throw new UnsupportedOperationException();
         }
 

--- a/src/main/java/ch/usi/si/seart/treesitter/TreeCursor.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/TreeCursor.java
@@ -133,6 +133,20 @@ public class TreeCursor extends External implements Cloneable {
     public native boolean gotoNextSibling();
 
     /**
+     * Move the cursor to the previous sibling of its current node.
+     * <p>
+     * Note that this method may be slower than {@link #gotoNextSibling()}
+     * due to how node positions are stored. In the worst case, this
+     * method may need to iterate through all the previous nodes
+     * up to the destination.
+     *
+     * @return true if the cursor successfully moved,
+     * and false if there was no previous sibling node
+     * @since 1.12.0
+     */
+    public native boolean gotoPrevSibling();
+
+    /**
      * Move the cursor to the parent of its current node.
      *
      * @return true if the cursor successfully moved,
@@ -236,6 +250,11 @@ public class TreeCursor extends External implements Cloneable {
 
         @Override
         public boolean gotoNextSibling() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean gotoPrevSibling() {
             throw new UnsupportedOperationException();
         }
 

--- a/src/test/java/ch/usi/si/seart/treesitter/TreeCursorTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/TreeCursorTest.java
@@ -42,14 +42,13 @@ class TreeCursorTest extends TestBase {
     }
 
     @Test
-    void testWalk() {
+    void testWalkLeftToRight() {
         Assertions.assertEquals("module", cursor.getCurrentTreeCursorNode().getType());
         Assertions.assertEquals("module", cursor.getCurrentNode().getType());
         Assertions.assertTrue(cursor.gotoFirstChild());
         Assertions.assertEquals("function_definition", cursor.getCurrentTreeCursorNode().getType());
         Assertions.assertEquals("function_definition", cursor.getCurrentNode().getType());
         Assertions.assertTrue(cursor.gotoFirstChild());
-
         Assertions.assertFalse(cursor.gotoPrevSibling());
         Assertions.assertEquals("def", cursor.getCurrentNode().getType());
         Assertions.assertTrue(cursor.gotoNextSibling());
@@ -64,10 +63,19 @@ class TreeCursorTest extends TestBase {
         Assertions.assertEquals("block", cursor.getCurrentNode().getType());
         Assertions.assertEquals("body", cursor.getCurrentFieldName());
         Assertions.assertFalse(cursor.gotoNextSibling());
-
         Assertions.assertTrue(cursor.gotoParent());
-        Assertions.assertTrue(cursor.gotoLastChild());
+        Assertions.assertTrue(cursor.gotoParent());
+        Assertions.assertFalse(cursor.gotoParent());
+    }
 
+    @Test
+    void testWalkRightToLeft() {
+        Assertions.assertEquals("module", cursor.getCurrentTreeCursorNode().getType());
+        Assertions.assertEquals("module", cursor.getCurrentNode().getType());
+        Assertions.assertTrue(cursor.gotoLastChild());
+        Assertions.assertEquals("function_definition", cursor.getCurrentTreeCursorNode().getType());
+        Assertions.assertEquals("function_definition", cursor.getCurrentNode().getType());
+        Assertions.assertTrue(cursor.gotoLastChild());
         Assertions.assertFalse(cursor.gotoNextSibling());
         Assertions.assertEquals("block", cursor.getCurrentNode().getType());
         Assertions.assertEquals("body", cursor.getCurrentFieldName());
@@ -82,6 +90,9 @@ class TreeCursorTest extends TestBase {
         Assertions.assertTrue(cursor.gotoPrevSibling());
         Assertions.assertEquals("def", cursor.getCurrentNode().getType());
         Assertions.assertFalse(cursor.gotoPrevSibling());
+        Assertions.assertTrue(cursor.gotoParent());
+        Assertions.assertTrue(cursor.gotoParent());
+        Assertions.assertFalse(cursor.gotoParent());
     }
 
     @Test

--- a/src/test/java/ch/usi/si/seart/treesitter/TreeCursorTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/TreeCursorTest.java
@@ -50,6 +50,7 @@ class TreeCursorTest extends TestBase {
         Assertions.assertEquals("function_definition", cursor.getCurrentNode().getType());
         Assertions.assertTrue(cursor.gotoFirstChild());
 
+        Assertions.assertFalse(cursor.gotoPrevSibling());
         Assertions.assertEquals("def", cursor.getCurrentNode().getType());
         Assertions.assertTrue(cursor.gotoNextSibling());
         Assertions.assertEquals("identifier", cursor.getCurrentNode().getType());
@@ -65,8 +66,22 @@ class TreeCursorTest extends TestBase {
         Assertions.assertFalse(cursor.gotoNextSibling());
 
         Assertions.assertTrue(cursor.gotoParent());
-        Assertions.assertEquals("function_definition", cursor.getCurrentNode().getType());
-        Assertions.assertTrue(cursor.gotoFirstChild());
+        Assertions.assertTrue(cursor.gotoLastChild());
+
+        Assertions.assertFalse(cursor.gotoNextSibling());
+        Assertions.assertEquals("block", cursor.getCurrentNode().getType());
+        Assertions.assertEquals("body", cursor.getCurrentFieldName());
+        Assertions.assertTrue(cursor.gotoPrevSibling());
+        Assertions.assertEquals(":", cursor.getCurrentNode().getType());
+        Assertions.assertTrue(cursor.gotoPrevSibling());
+        Assertions.assertEquals("parameters", cursor.getCurrentNode().getType());
+        Assertions.assertEquals("parameters", cursor.getCurrentFieldName());
+        Assertions.assertTrue(cursor.gotoPrevSibling());
+        Assertions.assertEquals("identifier", cursor.getCurrentNode().getType());
+        Assertions.assertEquals("name", cursor.getCurrentFieldName());
+        Assertions.assertTrue(cursor.gotoPrevSibling());
+        Assertions.assertEquals("def", cursor.getCurrentNode().getType());
+        Assertions.assertFalse(cursor.gotoPrevSibling());
     }
 
     @Test


### PR DESCRIPTION
This PR introduces two new method that exploit the newly introduced tree-sitter APIs (https://github.com/tree-sitter/tree-sitter/pull/2324). These include:

- `TreeCursor#gotoLastChild`
- `TreeCursor#gotoPrevSibling`

Note that both methods exist purely for convenience, and as the JavaDoc notes, may perform worse than the existing methods.