### PR TITLE
Remove `Language#_INVALID_`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,13 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-bom</artifactId>
+        <version>5.10.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -134,6 +141,16 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/ch/usi/si/seart/treesitter/Language.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Language.java
@@ -573,14 +573,6 @@ public enum Language {
                     )
             ));
 
-    Language() {
-        this(INVALID);
-    }
-
-    Language(long id) {
-        this(id, 0, 0, 0, 0, Collections.emptyList());
-    }
-
     Language(long id, String... extensions) {
         this(id, version(id), fields(id), states(id), symbols(id), List.of(extensions));
     }

--- a/src/main/java/ch/usi/si/seart/treesitter/Language.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Language.java
@@ -8,7 +8,6 @@ import lombok.Getter;
 import lombok.experimental.FieldDefaults;
 import org.apache.commons.io.FilenameUtils;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.TestOnly;
 
 import java.io.InputStream;
 import java.io.UncheckedIOException;
@@ -43,13 +42,6 @@ import java.util.stream.Stream;
 @Getter
 @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
 public enum Language {
-
-    /**
-     * Represents an invalid language.
-     * Used primarily for testing.
-     */
-    @TestOnly
-    _INVALID_(),
 
     /**
      * Ada programming language.

--- a/src/test/java/ch/usi/si/seart/treesitter/AbstractQueryTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/AbstractQueryTest.java
@@ -3,7 +3,7 @@ package ch.usi.si.seart.treesitter;
 import lombok.Cleanup;
 import org.junit.jupiter.api.Test;
 
-public abstract class AbstractQueryTest extends TestBase {
+public abstract class AbstractQueryTest extends BaseTest {
 
     protected Language getLanguage() {
         return Language.PYTHON;

--- a/src/test/java/ch/usi/si/seart/treesitter/BaseTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/BaseTest.java
@@ -8,13 +8,14 @@ public abstract class BaseTest {
 
     protected static final Language invalid;
 
-    protected final Node empty = new Node.Null();
-    protected final Node treeless = new Node(1, 1, 1, 1, 1L, null);
-    protected final Point _0_0_ = new Point(0, 0);
-    protected final Point _0_1_ = new Point(0, 1);
-    protected final Point _1_0_ = new Point(1, 0);
-    protected final Point _1_1_ = new Point(1, 1);
-    protected final Point _2_2_ = new Point(2, 2);
+    protected static final Node empty = new Node.Null();
+    protected static final Node treeless = new Node(1, 1, 1, 1, 1L, null);
+
+    protected static final Point _0_0_ = new Point(0, 0);
+    protected static final Point _0_1_ = new Point(0, 1);
+    protected static final Point _1_0_ = new Point(1, 0);
+    protected static final Point _1_1_ = new Point(1, 1);
+    protected static final Point _2_2_ = new Point(2, 2);
 
     static {
         LibraryLoader.load();

--- a/src/test/java/ch/usi/si/seart/treesitter/BaseTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/BaseTest.java
@@ -4,7 +4,7 @@ import org.mockito.Mockito;
 
 import java.util.List;
 
-public abstract class TestBase {
+public abstract class BaseTest {
 
     protected static final Language invalid;
 

--- a/src/test/java/ch/usi/si/seart/treesitter/LanguageTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/LanguageTest.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
-import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 class LanguageTest extends TestBase {
@@ -25,10 +24,7 @@ class LanguageTest extends TestBase {
 
         @Override
         public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) {
-            Predicate<Language> notInvalid = Predicate.not(Language._INVALID_::equals);
-            return Stream.of(Language.values())
-                    .filter(notInvalid)
-                    .map(Arguments::of);
+            return Stream.of(Language.values()).map(Arguments::of);
         }
     }
 
@@ -44,7 +40,7 @@ class LanguageTest extends TestBase {
         public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) {
             return Stream.of(
                     Arguments.of(NullPointerException.class, null),
-                    Arguments.of(UnsatisfiedLinkError.class, Language._INVALID_)
+                    Arguments.of(UnsatisfiedLinkError.class, invalid)
             );
         }
     }
@@ -114,9 +110,10 @@ class LanguageTest extends TestBase {
 
     @Test
     void testNextStateThrows() {
-        Assertions.assertThrows(NullPointerException.class, () -> Language.JAVA.nextState(null));
-        Assertions.assertThrows(NullPointerException.class, () -> Language._INVALID_.nextState(null));
-        Assertions.assertThrows(IllegalArgumentException.class, () -> Language.JAVA.nextState(empty));
-        Assertions.assertThrows(IllegalArgumentException.class, () -> Language._INVALID_.nextState(empty));
+        Language language = Language.PYTHON;
+        Assertions.assertThrows(NullPointerException.class, () -> language.nextState(null));
+        Assertions.assertThrows(NullPointerException.class, () -> invalid.nextState(null));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> language.nextState(empty));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> invalid.nextState(empty));
     }
 }

--- a/src/test/java/ch/usi/si/seart/treesitter/LanguageTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/LanguageTest.java
@@ -15,7 +15,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.stream.Stream;
 
-class LanguageTest extends TestBase {
+class LanguageTest extends BaseTest {
 
     @TempDir
     private static Path tmp;

--- a/src/test/java/ch/usi/si/seart/treesitter/LanguageTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/LanguageTest.java
@@ -19,6 +19,7 @@ class LanguageTest extends BaseTest {
 
     @TempDir
     private static Path tmp;
+    private static final Language language = Language.PYTHON;
 
     private static class ValidateProvider implements ArgumentsProvider {
 
@@ -101,7 +102,6 @@ class LanguageTest extends BaseTest {
 
     @Test
     void testNextState() {
-        Language language = Language.PYTHON;
         @Cleanup Parser parser = Parser.getFor(language);
         @Cleanup Tree tree = parser.parse("pass");
         Node root = tree.getRootNode();
@@ -110,7 +110,6 @@ class LanguageTest extends BaseTest {
 
     @Test
     void testNextStateThrows() {
-        Language language = Language.PYTHON;
         Assertions.assertThrows(NullPointerException.class, () -> language.nextState(null));
         Assertions.assertThrows(NullPointerException.class, () -> invalid.nextState(null));
         Assertions.assertThrows(IllegalArgumentException.class, () -> language.nextState(empty));

--- a/src/test/java/ch/usi/si/seart/treesitter/LookaheadIteratorTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/LookaheadIteratorTest.java
@@ -10,7 +10,7 @@ import java.util.Spliterators;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
-class LookaheadIteratorTest extends TestBase {
+class LookaheadIteratorTest extends BaseTest {
 
     private static final Language language = Language.JAVA;
 

--- a/src/test/java/ch/usi/si/seart/treesitter/NodeTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/NodeTest.java
@@ -17,7 +17,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.stream.Stream;
 
-class NodeTest extends TestBase {
+class NodeTest extends BaseTest {
 
     private static final String source = "def foo(bar, baz):\n  print(bar)\n  print(baz)";
     private static Parser parser;

--- a/src/test/java/ch/usi/si/seart/treesitter/ParserTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/ParserTest.java
@@ -22,7 +22,7 @@ import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
-class ParserTest extends TestBase {
+class ParserTest extends BaseTest {
 
     @TempDir
     private static Path tmp;

--- a/src/test/java/ch/usi/si/seart/treesitter/ParserTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/ParserTest.java
@@ -140,7 +140,7 @@ class ParserTest extends TestBase {
         public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) {
             return Stream.of(
                     Arguments.of(NullPointerException.class, null),
-                    Arguments.of(UnsatisfiedLinkError.class, Language._INVALID_)
+                    Arguments.of(UnsatisfiedLinkError.class, invalid)
             );
         }
     }

--- a/src/test/java/ch/usi/si/seart/treesitter/PointTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/PointTest.java
@@ -7,7 +7,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-class PointTest extends TestBase {
+class PointTest extends BaseTest {
 
     @Test
     void testIsOrigin() {

--- a/src/test/java/ch/usi/si/seart/treesitter/QueryCursorTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/QueryCursorTest.java
@@ -26,7 +26,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-class QueryCursorTest extends TestBase {
+class QueryCursorTest extends BaseTest {
 
     private static final String source = "class Hello { /* Comment 1 */ /* Comment 2 */ /* Comment 3 */ }";
     private static final String pattern = "(block_comment) @comment";

--- a/src/test/java/ch/usi/si/seart/treesitter/QueryTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/QueryTest.java
@@ -20,7 +20,7 @@ import java.util.Map;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-class QueryTest extends TestBase {
+class QueryTest extends BaseTest {
 
     private static final Language language = Language.JAVA;
 

--- a/src/test/java/ch/usi/si/seart/treesitter/QueryTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/QueryTest.java
@@ -63,7 +63,7 @@ class QueryTest extends TestBase {
         @Override
         public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) {
             return Stream.of(
-                    Arguments.of(UnsatisfiedLinkError.class, Language._INVALID_, "(_)"),
+                    Arguments.of(UnsatisfiedLinkError.class, invalid, "(_)"),
                     Arguments.of(QueryCaptureException.class, Language.JAVA, "(#eq? @key @value)"),
                     Arguments.of(QueryFieldException.class, Language.JAVA, "(program unknown: (_))"),
                     Arguments.of(QueryNodeTypeException.class, Language.JAVA, "(null)"),

--- a/src/test/java/ch/usi/si/seart/treesitter/TestBase.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/TestBase.java
@@ -1,6 +1,12 @@
 package ch.usi.si.seart.treesitter;
 
+import org.mockito.Mockito;
+
+import java.util.List;
+
 public abstract class TestBase {
+
+    protected static final Language invalid;
 
     protected final Node empty = new Node.Null();
     protected final Node treeless = new Node(1, 1, 1, 1, 1L, null);
@@ -12,5 +18,18 @@ public abstract class TestBase {
 
     static {
         LibraryLoader.load();
+        invalid = Mockito.mock(Language.class);
+
+        Mockito.when(invalid.name()).thenReturn("INVALID");
+        Mockito.when(invalid.ordinal()).thenReturn(Language.values().length);
+
+        Mockito.when(invalid.getId()).thenReturn(0L);
+        Mockito.when(invalid.getVersion()).thenReturn(0);
+        Mockito.when(invalid.getTotalFields()).thenReturn(0);
+        Mockito.when(invalid.getTotalStates()).thenReturn(0);
+        Mockito.when(invalid.getTotalSymbols()).thenReturn(0);
+        Mockito.when(invalid.getSymbols()).thenReturn(List.of());
+
+        Mockito.when(invalid.nextState(Mockito.any())).thenCallRealMethod();
     }
 }

--- a/src/test/java/ch/usi/si/seart/treesitter/TreeCursorTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/TreeCursorTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
-class TreeCursorTest extends TestBase {
+class TreeCursorTest extends BaseTest {
 
     private static Parser parser;
     private static Tree tree;

--- a/src/test/java/ch/usi/si/seart/treesitter/TreeTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/TreeTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
 
 import java.util.stream.Stream;
 
-class TreeTest extends TestBase {
+class TreeTest extends BaseTest {
 
     private static final String source = "class Main {\n    // This is a line comment\n}\n";
     private static Parser parser;

--- a/src/test/java/ch/usi/si/seart/treesitter/printer/DotGraphPrinterTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/printer/DotGraphPrinterTest.java
@@ -1,8 +1,8 @@
 package ch.usi.si.seart.treesitter.printer;
 
+import ch.usi.si.seart.treesitter.BaseTest;
 import ch.usi.si.seart.treesitter.Language;
 import ch.usi.si.seart.treesitter.Parser;
-import ch.usi.si.seart.treesitter.TestBase;
 import ch.usi.si.seart.treesitter.Tree;
 import lombok.Cleanup;
 import lombok.SneakyThrows;
@@ -14,7 +14,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-class DotGraphPrinterTest extends TestBase {
+class DotGraphPrinterTest extends BaseTest {
 
     private static final String source =
             "package ch.usi.si;\n" +

--- a/src/test/java/ch/usi/si/seart/treesitter/printer/PrinterTestBase.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/printer/PrinterTestBase.java
@@ -1,8 +1,8 @@
 package ch.usi.si.seart.treesitter.printer;
 
+import ch.usi.si.seart.treesitter.BaseTest;
 import ch.usi.si.seart.treesitter.Language;
 import ch.usi.si.seart.treesitter.Parser;
-import ch.usi.si.seart.treesitter.TestBase;
 import ch.usi.si.seart.treesitter.Tree;
 import ch.usi.si.seart.treesitter.TreeCursor;
 import lombok.Cleanup;
@@ -15,7 +15,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-public abstract class PrinterTestBase extends TestBase {
+public abstract class PrinterTestBase extends BaseTest {
 
     @Test
     protected void testPrint() {


### PR DESCRIPTION
Removed the test-only enum value, and replaced it with a Mockito-mocked instance. Don't ask why this took so long to do. Includes some minor changes to the tests. Other than that, no APIs were affected.