### PR TITLE
Add `Tree` method for obtaining ranges of code changed in edits

### DIFF
--- a/lib/ch_usi_si_seart_treesitter.cc
+++ b/lib/ch_usi_si_seart_treesitter.cc
@@ -7,6 +7,7 @@ jclass _stringClass;
 
 jclass _listClass;
 jmethodID _listGet;
+jmethodID _listOfStaticMethod;
 
 jclass _mapClass;
 jclass _mapEntryClass;
@@ -162,6 +163,7 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved) {
 
   _loadClass(_listClass, "java/util/List")
   _loadMethod(_listGet, _listClass, "get", "(I)Ljava/lang/Object;")
+  _loadStaticMethod(_listOfStaticMethod, _listClass, "of", "([Ljava/lang/Object;)Ljava/util/List;")
 
   _loadClass(_mapClass, "java/util/Map")
   _loadClass(_mapEntryClass, "java/util/Map$Entry")

--- a/lib/ch_usi_si_seart_treesitter.cc
+++ b/lib/ch_usi_si_seart_treesitter.cc
@@ -498,8 +498,8 @@ jobject __marshalRange(JNIEnv* env, TSRange range) {
   return env->NewObject(
     _rangeClass,
     _rangeConstructor,
-    (jint)range.start_byte,
-    (jint)range.end_byte,
+    (jint)range.start_byte / 2,
+    (jint)range.end_byte / 2,
     __marshalPoint(env, range.start_point),
     __marshalPoint(env, range.end_point)
   );
@@ -509,8 +509,8 @@ TSRange __unmarshalRange(JNIEnv* env, jobject rangeObject) {
   return (TSRange) {
     __unmarshalPoint(env, env->GetObjectField(rangeObject, _rangeStartPointField)),
     __unmarshalPoint(env, env->GetObjectField(rangeObject, _rangeEndPointField)),
-    (uint32_t)env->GetIntField(rangeObject, _rangeStartByteField),
-    (uint32_t)env->GetIntField(rangeObject, _rangeEndByteField)
+    (uint32_t)env->GetIntField(rangeObject, _rangeStartByteField) * 2,
+    (uint32_t)env->GetIntField(rangeObject, _rangeEndByteField) * 2
   };
 }
 

--- a/lib/ch_usi_si_seart_treesitter.cc
+++ b/lib/ch_usi_si_seart_treesitter.cc
@@ -516,9 +516,9 @@ TSRange __unmarshalRange(JNIEnv* env, jobject rangeObject) {
 
 TSInputEdit __unmarshalInputEdit(JNIEnv* env, jobject inputEditObject) {
   return (TSInputEdit) {
-    (uint32_t)env->GetIntField(inputEditObject, _inputEditStartByteField),
-    (uint32_t)env->GetIntField(inputEditObject, _inputEditOldEndByteField),
-    (uint32_t)env->GetIntField(inputEditObject, _inputEditNewEndByteField),
+    (uint32_t)env->GetIntField(inputEditObject, _inputEditStartByteField) * 2,
+    (uint32_t)env->GetIntField(inputEditObject, _inputEditOldEndByteField) * 2,
+    (uint32_t)env->GetIntField(inputEditObject, _inputEditNewEndByteField) * 2,
     __unmarshalPoint(env, env->GetObjectField(inputEditObject, _inputEditStartPointField)),
     __unmarshalPoint(env, env->GetObjectField(inputEditObject, _inputEditOldEndPointField)),
     __unmarshalPoint(env, env->GetObjectField(inputEditObject, _inputEditNewEndPointField)),

--- a/lib/ch_usi_si_seart_treesitter.cc
+++ b/lib/ch_usi_si_seart_treesitter.cc
@@ -30,6 +30,13 @@ jfieldID _pointRowField;
 jfieldID _pointColumnField;
 jmethodID _pointOriginStaticMethod;
 
+jclass _rangeClass;
+jmethodID _rangeConstructor;
+jfieldID _rangeStartByteField;
+jfieldID _rangeEndByteField;
+jfieldID _rangeStartPointField;
+jfieldID _rangeEndPointField;
+
 jclass _queryMatchClass;
 jmethodID _queryMatchConstructor;
 jfieldID _queryMatchIdField;
@@ -179,6 +186,14 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved) {
   _loadField(_pointColumnField, _pointClass, "column", "I")
   _loadStaticMethod(_pointOriginStaticMethod, _pointClass, "ORIGIN", "()Lch/usi/si/seart/treesitter/Point;")
 
+  _loadClass(_rangeClass, "ch/usi/si/seart/treesitter/Range")
+  _loadConstructor(_rangeConstructor, _rangeClass,
+    "(IILch/usi/si/seart/treesitter/Point;Lch/usi/si/seart/treesitter/Point;)V")
+  _loadField(_rangeStartByteField, _rangeClass, "startByte", "I")
+  _loadField(_rangeEndByteField, _rangeClass, "endByte", "I")
+  _loadField(_rangeStartPointField, _rangeClass, "startPoint", "Lch/usi/si/seart/treesitter/Point;")
+  _loadField(_rangeEndPointField, _rangeClass, "endPoint", "Lch/usi/si/seart/treesitter/Point;")
+
   _loadClass(_queryMatchClass, "ch/usi/si/seart/treesitter/QueryMatch")
   _loadConstructor(_queryMatchConstructor, _queryMatchClass,
     "(ILch/usi/si/seart/treesitter/Pattern;[Ljava/util/Map$Entry;)V")
@@ -315,6 +330,7 @@ void JNI_OnUnload(JavaVM* vm, void* reserved) {
   _unload(_externalClass)
   _unload(_nodeClass)
   _unload(_pointClass)
+  _unload(_rangeClass)
   _unload(_queryMatchClass)
   _unload(_inputEditClass)
   _unload(_treeCursorNodeClass)

--- a/lib/ch_usi_si_seart_treesitter.cc
+++ b/lib/ch_usi_si_seart_treesitter.cc
@@ -492,6 +492,26 @@ TSPoint __unmarshalPoint(JNIEnv* env, jobject pointObject) {
   };
 }
 
+jobject __marshalRange(JNIEnv* env, TSRange range) {
+  return env->NewObject(
+    _rangeClass,
+    _rangeConstructor,
+    (jint)range.start_byte,
+    (jint)range.end_byte,
+    __marshalPoint(env, range.start_point),
+    __marshalPoint(env, range.end_point)
+  );
+}
+
+TSRange __unmarshalRange(JNIEnv* env, jobject rangeObject) {
+  return (TSRange) {
+    __unmarshalPoint(env, env->GetObjectField(rangeObject, _rangeStartPointField)),
+    __unmarshalPoint(env, env->GetObjectField(rangeObject, _rangeEndPointField)),
+    (uint32_t)env->GetIntField(rangeObject, _rangeStartByteField),
+    (uint32_t)env->GetIntField(rangeObject, _rangeEndByteField)
+  };
+}
+
 TSInputEdit __unmarshalInputEdit(JNIEnv* env, jobject inputEditObject) {
   return (TSInputEdit) {
     (uint32_t)env->GetIntField(inputEditObject, _inputEditStartByteField),

--- a/lib/ch_usi_si_seart_treesitter.h
+++ b/lib/ch_usi_si_seart_treesitter.h
@@ -8,6 +8,7 @@ extern jclass _stringClass;
 
 extern jclass _listClass;
 extern jmethodID _listGet;
+extern jmethodID _listOfStaticMethod;
 
 extern jclass _mapClass;
 extern jclass _mapEntryClass;

--- a/lib/ch_usi_si_seart_treesitter.h
+++ b/lib/ch_usi_si_seart_treesitter.h
@@ -43,6 +43,13 @@ extern jfieldID _pointRowField;
 extern jfieldID _pointColumnField;
 extern jmethodID _pointOriginStaticMethod;
 
+extern jclass _rangeClass;
+extern jmethodID _rangeConstructor;
+extern jfieldID _rangeStartByteField;
+extern jfieldID _rangeEndByteField;
+extern jfieldID _rangeStartPointField;
+extern jfieldID _rangeEndPointField;
+
 extern jclass _queryMatchClass;
 extern jmethodID _queryMatchConstructor;
 extern jfieldID _queryMatchIdField;

--- a/lib/ch_usi_si_seart_treesitter.h
+++ b/lib/ch_usi_si_seart_treesitter.h
@@ -257,6 +257,10 @@ jobject __marshalPoint(JNIEnv* env, TSPoint point);
 
 TSPoint __unmarshalPoint(JNIEnv* env, jobject pointObject);
 
+jobject __marshalRange(JNIEnv* env, TSRange range);
+
+TSRange __unmarshalRange(JNIEnv* env, jobject rangeObject);
+
 TSInputEdit __unmarshalInputEdit(JNIEnv* env, jobject inputEdit);
 
 const TSLanguage* __unmarshalLanguage(JNIEnv* env, jobject languageObject);

--- a/lib/ch_usi_si_seart_treesitter_Tree.cc
+++ b/lib/ch_usi_si_seart_treesitter_Tree.cc
@@ -21,6 +21,21 @@ JNIEXPORT void JNICALL Java_ch_usi_si_seart_treesitter_Tree_edit(
   ts_tree_edit((TSTree*)tree, &inputEdit);
 }
 
+JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Tree_getChangedRanges(
+  JNIEnv* env, jobject thisObject, jobject otherObject) {
+  TSTree* old_tree = (TSTree*)__getPointer(env, thisObject);
+  TSTree* new_tree = (TSTree*)__getPointer(env, otherObject);
+  uint32_t* length = new uint32_t;
+  TSRange* ranges = ts_tree_get_changed_ranges(old_tree, new_tree, length);
+  jobjectArray array = env->NewObjectArray(*length, _rangeClass, NULL);
+  for (uint32_t i = 0; i < *length; i++) {
+    TSRange range = ranges[i];
+    jobject rangeObject = __marshalRange(env, range);
+    env->SetObjectArrayElement(array, i, rangeObject);
+  }
+  return env->CallStaticObjectMethod(_listClass, _listOfStaticMethod, array);
+}
+
 JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Tree_getRootNode(
   JNIEnv* env, jobject thisObject) {
   jlong tree = __getPointer(env, thisObject);

--- a/lib/ch_usi_si_seart_treesitter_Tree.h
+++ b/lib/ch_usi_si_seart_treesitter_Tree.h
@@ -25,6 +25,14 @@ JNIEXPORT void JNICALL Java_ch_usi_si_seart_treesitter_Tree_edit
 
 /*
  * Class:     ch_usi_si_seart_treesitter_Tree
+ * Method:    getChangedRanges
+ * Signature: (Lch/usi/si/seart/treesitter/Tree;)Ljava/util/List;
+ */
+JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Tree_getChangedRanges
+  (JNIEnv *, jobject, jobject);
+
+/*
+ * Class:     ch_usi_si_seart_treesitter_Tree
  * Method:    getRootNode
  * Signature: ()Lch/usi/si/seart/treesitter/Node;
  */

--- a/src/main/java/ch/usi/si/seart/treesitter/Tree.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Tree.java
@@ -9,6 +9,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Iterator;
+import java.util.List;
 
 /**
  * A Tree represents the syntax tree of an entire source code file.
@@ -43,6 +44,24 @@ public class Tree extends External implements Iterable<Node>, Cloneable {
      * <strong>both</strong> byte offsets and row/column coordinates
      */
     public native void edit(@NotNull InputEdit edit);
+
+    /**
+     * Compare this old edited syntax tree to a new syntax tree representing the same document,
+     * returning a sequence of {@link Range} instances, their coordinates corresponding to changes
+     * made to the syntactic structure.
+     * <p>
+     * For this to work correctly, this syntax tree must have been edited such that its
+     * ranges match up to the new tree. Generally, you'll want to call this method right
+     * after calling one of the {@link Parser} methods.
+     *
+     * @param other the tree to compare with
+     * @return a list of ranges that have been changed
+     * @throws NullPointerException if {@code other} is null
+     * @since 1.12.0
+     * @see Parser#parse(String, Tree)
+     * @see Parser#parse(java.nio.file.Path, Tree) Parser.parse(Path, Tree)
+     */
+    public native List<Range> getChangedRanges(@NotNull Tree other);
 
     /**
      * Get the topmost {@link Node} of the syntax tree.


### PR DESCRIPTION
This PR introduces the `Tree#getChangedRanges` method.