### PR TITLE
Fix various memory leaks in native code

### DIFF
--- a/lib/ch_usi_si_seart_treesitter_Capture.cc
+++ b/lib/ch_usi_si_seart_treesitter_Capture.cc
@@ -16,4 +16,5 @@ JNIEXPORT void JNICALL Java_ch_usi_si_seart_treesitter_Capture_disable(
   uint32_t length = env->GetStringLength(name);
   const char* characters = env->GetStringUTFChars(name, NULL);
   ts_query_disable_capture(query, characters, length);
+  env->ReleaseStringUTFChars(name, characters);
 }

--- a/lib/ch_usi_si_seart_treesitter_Language.cc
+++ b/lib/ch_usi_si_seart_treesitter_Language.cc
@@ -510,18 +510,20 @@ JNIEXPORT jlong JNICALL Java_ch_usi_si_seart_treesitter_Language_zig(
 
 JNIEXPORT jint JNICALL Java_ch_usi_si_seart_treesitter_Language_version(
   JNIEnv* env, jclass self, jlong id) {
-  return (jint)ts_language_version((const TSLanguage*)id);
+  TSLanguage* language = (TSLanguage*)id;
+  return (jint)ts_language_version(language);
 }
 
 JNIEXPORT jint JNICALL Java_ch_usi_si_seart_treesitter_Language_symbols(
   JNIEnv* env, jclass self, jlong id) {
-  return (jint)ts_language_symbol_count((const TSLanguage*)id);
+  TSLanguage* language = (TSLanguage*)id;
+  return (jint)ts_language_symbol_count(language);
 }
 
 JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Language_symbol(
   JNIEnv* env, jclass self, jlong languageId, jint symbolId) {
   TSSymbol symbol = (TSSymbol)symbolId;
-  const TSLanguage* language = (const TSLanguage*)languageId;
+  TSLanguage* language = (TSLanguage*)languageId;
   const char* name = ts_language_symbol_name(language, symbol);
   TSSymbolType type = ts_language_symbol_type(language, symbol);
   return env->NewObject(
@@ -535,12 +537,14 @@ JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Language_symbol(
 
 JNIEXPORT jint JNICALL Java_ch_usi_si_seart_treesitter_Language_fields(
   JNIEnv* env, jclass self, jlong id) {
-  return (jint)ts_language_field_count((const TSLanguage*)id);
+  TSLanguage* language = (TSLanguage*)id;
+  return (jint)ts_language_field_count(language);
 }
 
 JNIEXPORT jint JNICALL Java_ch_usi_si_seart_treesitter_Language_states(
   JNIEnv* env, jclass self, jlong id) {
-  return (jint)ts_language_state_count((const TSLanguage*)id);
+  TSLanguage* language = (TSLanguage*)id;
+  return (jint)ts_language_state_count(language);
 }
 
 JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Language_iterator(
@@ -568,9 +572,9 @@ JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Language_iterator(
 
 JNIEXPORT jint JNICALL Java_ch_usi_si_seart_treesitter_Language_nextState(
   JNIEnv* env, jclass self, jlong id, jint state, jint symbol) {
-  if (id == (jlong)ch_usi_si_seart_treesitter_Language_INVALID) return (jint)(-1);
+  if (id == (jlong)(ch_usi_si_seart_treesitter_Language_INVALID)) return (jint)(-1);
   return (jint)ts_language_next_state(
-    (const TSLanguage*)id,
+    (TSLanguage*)id,
     (TSStateId)state,
     (TSSymbol)symbol
   );

--- a/lib/ch_usi_si_seart_treesitter_Node.cc
+++ b/lib/ch_usi_si_seart_treesitter_Node.cc
@@ -34,6 +34,7 @@ JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Node_getChildByFieldNa
   const char* childName = env->GetStringUTFChars(name, NULL);
   TSNode node = __unmarshalNode(env, thisObject);
   TSNode child = ts_node_child_by_field_name(node, childName, length);
+  env->ReleaseStringUTFChars(name, childName);
   if (ts_node_is_null(child)) return NULL;
   jobject childObject = __marshalNode(env, child);
   __copyTree(env, thisObject, childObject);

--- a/lib/ch_usi_si_seart_treesitter_Parser.cc
+++ b/lib/ch_usi_si_seart_treesitter_Parser.cc
@@ -61,7 +61,7 @@ JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Parser_getIncludedRang
 JNIEXPORT void JNICALL Java_ch_usi_si_seart_treesitter_Parser_setIncludedRanges(
   JNIEnv* env, jobject thisObject, jobjectArray rangeObjectArray, jint length) {
   TSParser* parser = (TSParser*)__getPointer(env, thisObject);
-  TSRange* ranges = new TSRange[length];
+  TSRange ranges[length];
   for (int i = 0; i < length; i++) {
     jobject rangeObject = env->GetObjectArrayElement(rangeObjectArray, i);
     ranges[i] = __unmarshalRange(env, rangeObject);

--- a/lib/ch_usi_si_seart_treesitter_Parser.cc
+++ b/lib/ch_usi_si_seart_treesitter_Parser.cc
@@ -39,17 +39,16 @@ JNIEXPORT void JNICALL Java_ch_usi_si_seart_treesitter_Parser_setLanguage(
 JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Parser_getIncludedRanges(
   JNIEnv* env, jobject thisObject) {
   TSParser* parser = (TSParser*)__getPointer(env, thisObject);
-  uint32_t* length = new uint32_t;
-  const TSRange* ranges = ts_parser_included_ranges(parser, length);
+  uint32_t length = 0;
+  const TSRange* ranges = ts_parser_included_ranges(parser, &length);
   jobject result;
   if (
-    *length == 0 ||
-    (*length == 1 && __isDefaultRange(ranges[0]))
+    length == 0 || (length == 1 && __isDefaultRange(ranges[0]))
   ) {
     result = env->CallStaticObjectMethod(_collectionsClass, _collectionsEmptyListStaticMethod);
   } else {
-    jobjectArray array = env->NewObjectArray(*length, _rangeClass, NULL);
-    for (uint32_t i = 0; i < *length; i++) {
+    jobjectArray array = env->NewObjectArray(length, _rangeClass, NULL);
+    for (uint32_t i = 0; i < length; i++) {
       TSRange range = ranges[i];
       jobject rangeObject = __marshalRange(env, range);
       env->SetObjectArrayElement(array, i, rangeObject);

--- a/lib/ch_usi_si_seart_treesitter_Parser_Builder.cc
+++ b/lib/ch_usi_si_seart_treesitter_Parser_Builder.cc
@@ -19,7 +19,7 @@ JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Parser_00024Builder_bu
   } else if (timeout > 0) {
     ts_parser_set_timeout_micros(parser, (uint64_t)timeout);
   }
-  TSRange* ranges = new TSRange[length];
+  TSRange ranges[length];
   for (int i = 0; i < length; i++) {
     jobject rangeObject = env->GetObjectArrayElement(rangeObjectArray, i);
     ranges[i] = __unmarshalRange(env, rangeObject);
@@ -34,6 +34,6 @@ JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Parser_00024Builder_bu
       _parserConstructor,
       (jlong)parser,
       languageObject
-    );    
+    );
   }
 }

--- a/lib/ch_usi_si_seart_treesitter_Tree.cc
+++ b/lib/ch_usi_si_seart_treesitter_Tree.cc
@@ -25,14 +25,15 @@ JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Tree_getChangedRanges(
   JNIEnv* env, jobject thisObject, jobject otherObject) {
   TSTree* old_tree = (TSTree*)__getPointer(env, thisObject);
   TSTree* new_tree = (TSTree*)__getPointer(env, otherObject);
-  uint32_t* length = new uint32_t;
-  TSRange* ranges = ts_tree_get_changed_ranges(old_tree, new_tree, length);
-  jobjectArray array = env->NewObjectArray(*length, _rangeClass, NULL);
-  for (uint32_t i = 0; i < *length; i++) {
+  uint32_t length = 0;
+  TSRange* ranges = ts_tree_get_changed_ranges(old_tree, new_tree, &length);
+  jobjectArray array = env->NewObjectArray(length, _rangeClass, NULL);
+  for (uint32_t i = 0; i < length; i++) {
     TSRange range = ranges[i];
     jobject rangeObject = __marshalRange(env, range);
     env->SetObjectArrayElement(array, i, rangeObject);
   }
+  delete[] ranges;
   return env->CallStaticObjectMethod(_listClass, _listOfStaticMethod, array);
 }
 

--- a/lib/ch_usi_si_seart_treesitter_Tree.cc
+++ b/lib/ch_usi_si_seart_treesitter_Tree.cc
@@ -12,13 +12,13 @@ JNIEXPORT void JNICALL Java_ch_usi_si_seart_treesitter_Tree_delete(
 
 JNIEXPORT void JNICALL Java_ch_usi_si_seart_treesitter_Tree_edit(
   JNIEnv* env, jobject thisObject, jobject inputEditObject) {
-  jlong tree = __getPointer(env, thisObject);
+  TSTree* tree = (TSTree*)__getPointer(env, thisObject);
   if (inputEditObject == NULL) {
     __throwNPE(env, "Input edit must not be null!");
-    return;
+  } else {
+    TSInputEdit inputEdit = __unmarshalInputEdit(env, inputEditObject);
+    ts_tree_edit(tree, &inputEdit);
   }
-  TSInputEdit inputEdit = __unmarshalInputEdit(env, inputEditObject);
-  ts_tree_edit((TSTree*)tree, &inputEdit);
 }
 
 JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Tree_getChangedRanges(
@@ -39,8 +39,8 @@ JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Tree_getChangedRanges(
 
 JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Tree_getRootNode(
   JNIEnv* env, jobject thisObject) {
-  jlong tree = __getPointer(env, thisObject);
-  TSNode node = ts_tree_root_node((TSTree*)tree);
+  TSTree* tree = (TSTree*)__getPointer(env, thisObject);
+  TSNode node = ts_tree_root_node(tree);
   jobject nodeObject = __marshalNode(env, node);
   _setNodeTreeField(nodeObject, thisObject);
   return nodeObject;
@@ -50,7 +50,12 @@ JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Tree_clone(
   JNIEnv* env, jobject thisObject) {
   jobject languageObject = env->GetObjectField(thisObject, _treeLanguageField);
   jobject sourceObject = env->GetObjectField(thisObject, _treeSourceField);
-  jlong tree = __getPointer(env, thisObject);
-  jlong copy = (jlong)ts_tree_copy((const TSTree*)tree);
-  return env->NewObject(_treeClass, _treeConstructor, copy, languageObject, sourceObject);
+  TSTree* tree = (TSTree*)__getPointer(env, thisObject);
+  return env->NewObject(
+    _treeClass,
+    _treeConstructor,
+    (jlong)ts_tree_copy(tree),
+    languageObject,
+    sourceObject
+  );
 }

--- a/lib/ch_usi_si_seart_treesitter_TreeCursor.cc
+++ b/lib/ch_usi_si_seart_treesitter_TreeCursor.cc
@@ -202,7 +202,7 @@ JNIEXPORT jboolean JNICALL Java_ch_usi_si_seart_treesitter_TreeCursor_reset(
 JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_TreeCursor_clone(
   JNIEnv* env, jobject thisObject) {
   jobject treeObject = env->GetObjectField(thisObject, _treeCursorTreeField);
-  const TSTreeCursor* cursor = (const TSTreeCursor*)__getPointer(env, thisObject);
+  TSTreeCursor* cursor = (TSTreeCursor*)__getPointer(env, thisObject);
   TSTreeCursor copy = ts_tree_cursor_copy(cursor);
   return env->NewObject(
     _treeCursorClass,


### PR DESCRIPTION
Affects native code from the following classes:
- `Query#Builder`
- `Parser#Builder`
- `Parser`
- `Capture`
- `Node`
- `Tree`