### PR TITLE
Add `Parser` logging

### DIFF
--- a/lib/ch_usi_si_seart_treesitter.cc
+++ b/lib/ch_usi_si_seart_treesitter.cc
@@ -178,6 +178,16 @@ const TSRange RANGE_DEFAULT = {
   .end_byte = UINT32_MAX,
 };
 
+const char* JNI_CALL_RESULT_NAMES[] = {
+  "OK",
+  "Unknown Error",
+  "Thread Detached from the VM",
+  "JNI Version Error",
+  "Not Enough Memory",
+  "VM Already Created",
+  "Invalid Arguments"
+};
+
 const char* LOG_TYPE_NAMES[] = {
   "PARSE",
   "LEX"

--- a/lib/ch_usi_si_seart_treesitter.cc
+++ b/lib/ch_usi_si_seart_treesitter.cc
@@ -174,10 +174,13 @@ const TSRange RANGE_DEFAULT = {
   .end_byte = UINT32_MAX,
 };
 
+JavaVM* JVM = NULL;
+
 jclass QUERY_EXCEPTION_CLASSES[7];
 jmethodID QUERY_EXCEPTION_CONSTRUCTORS[7];
 
 jint JNI_OnLoad(JavaVM* vm, void* reserved) {
+  JVM = vm;
   JNIEnv* env;
   if (vm->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION) != JNI_OK) {
     return JNI_ERR;

--- a/lib/ch_usi_si_seart_treesitter.cc
+++ b/lib/ch_usi_si_seart_treesitter.cc
@@ -157,6 +157,10 @@ jmethodID _parsingExceptionConstructor;
 jclass _incompatibleLanguageExceptionClass;
 jmethodID _incompatibleLanguageExceptionConstructor;
 
+jclass _loggerClass;
+
+jclass _markerFactoryClass;
+
 const TSPoint POINT_ORIGIN = {
   .row = 0,
   .column = 0,
@@ -350,6 +354,10 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved) {
   _loadConstructor(_incompatibleLanguageExceptionConstructor, _incompatibleLanguageExceptionClass,
     "(Lch/usi/si/seart/treesitter/Language;)V")
 
+  _loadClass(_loggerClass, "org/slf4j/Logger")
+
+  _loadClass(_markerFactoryClass, "org/slf4j/MarkerFactory")
+
   QUERY_EXCEPTION_CLASSES[0] = NULL;
   QUERY_EXCEPTION_CLASSES[1] = _querySyntaxExceptionClass;
   QUERY_EXCEPTION_CLASSES[2] = _queryNodeTypeExceptionClass;
@@ -411,6 +419,8 @@ void JNI_OnUnload(JavaVM* vm, void* reserved) {
   _unload(_queryStructureExceptionClass)
   _unload(_parsingExceptionClass)
   _unload(_incompatibleLanguageExceptionClass)
+  _unload(_loggerClass)
+  _unload(_markerFactoryClass)
 }
 
 ComparisonResult intcmp(uint32_t x, uint32_t y) {

--- a/lib/ch_usi_si_seart_treesitter.cc
+++ b/lib/ch_usi_si_seart_treesitter.cc
@@ -178,6 +178,11 @@ const TSRange RANGE_DEFAULT = {
   .end_byte = UINT32_MAX,
 };
 
+const char* LOG_TYPE_NAMES[] = {
+  "PARSE",
+  "LEX"
+};
+
 JavaVM* JVM = NULL;
 
 jclass QUERY_EXCEPTION_CLASSES[7];

--- a/lib/ch_usi_si_seart_treesitter.h
+++ b/lib/ch_usi_si_seart_treesitter.h
@@ -159,8 +159,10 @@ extern jclass _incompatibleLanguageExceptionClass;
 extern jmethodID _incompatibleLanguageExceptionConstructor;
 
 extern jclass _loggerClass;
+extern jmethodID _loggerDebugMethod;
 
 extern jclass _markerFactoryClass;
+extern jmethodID _markerFactoryGetMarkerStaticMethod;
 
 #ifdef __cplusplus
 extern "C" {
@@ -289,6 +291,8 @@ TSRange __unmarshalRange(JNIEnv* env, jobject rangeObject);
 TSInputEdit __unmarshalInputEdit(JNIEnv* env, jobject inputEdit);
 
 const TSLanguage* __unmarshalLanguage(JNIEnv* env, jobject languageObject);
+
+void __log_in_java(void* payload, TSLogType log_type, const char* buffer);
 
 #ifdef TS_LANGUAGE_ADA
 TSLanguage* tree_sitter_ada();

--- a/lib/ch_usi_si_seart_treesitter.h
+++ b/lib/ch_usi_si_seart_treesitter.h
@@ -158,6 +158,10 @@ extern jmethodID _parsingExceptionConstructor;
 extern jclass _incompatibleLanguageExceptionClass;
 extern jmethodID _incompatibleLanguageExceptionConstructor;
 
+extern jclass _loggerClass;
+
+extern jclass _markerFactoryClass;
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/lib/ch_usi_si_seart_treesitter_Parser.cc
+++ b/lib/ch_usi_si_seart_treesitter_Parser.cc
@@ -25,6 +25,24 @@ JNIEXPORT void JNICALL Java_ch_usi_si_seart_treesitter_Parser_setLanguage(
   }
 }
 
+JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Parser_getLogger(
+  JNIEnv* env, jobject thisObject) {
+  TSParser* parser = (TSParser*)__getPointer(env, thisObject);
+  TSLogger logger = ts_parser_logger(parser);
+  jobject loggerObject = reinterpret_cast<jobject>(logger.payload);
+  return env->NewLocalRef(loggerObject);
+}
+
+JNIEXPORT void JNICALL Java_ch_usi_si_seart_treesitter_Parser_setLogger(
+  JNIEnv* env, jobject thisObject, jobject loggerObject) {
+  TSParser* parser = (TSParser*)__getPointer(env, thisObject);
+  TSLogger logger = ts_parser_logger(parser);
+  jobject globalObject = reinterpret_cast<jobject>(logger.payload);
+  if (globalObject != NULL) env->DeleteGlobalRef(globalObject);
+  logger.payload = reinterpret_cast<void*>(env->NewGlobalRef(loggerObject));
+  ts_parser_set_logger(parser, logger);
+}
+
 JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Parser_getIncludedRanges(
   JNIEnv* env, jobject thisObject) {
   TSParser* parser = (TSParser*)__getPointer(env, thisObject);

--- a/lib/ch_usi_si_seart_treesitter_Parser.h
+++ b/lib/ch_usi_si_seart_treesitter_Parser.h
@@ -25,6 +25,22 @@ JNIEXPORT void JNICALL Java_ch_usi_si_seart_treesitter_Parser_setLanguage
 
 /*
  * Class:     ch_usi_si_seart_treesitter_Parser
+ * Method:    getLogger
+ * Signature: ()Lorg/slf4j/Logger;
+ */
+JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Parser_getLogger
+  (JNIEnv *, jobject);
+
+/*
+ * Class:     ch_usi_si_seart_treesitter_Parser
+ * Method:    setLogger
+ * Signature: (Lorg/slf4j/Logger;)V
+ */
+JNIEXPORT void JNICALL Java_ch_usi_si_seart_treesitter_Parser_setLogger
+  (JNIEnv *, jobject, jobject);
+
+/*
+ * Class:     ch_usi_si_seart_treesitter_Parser
  * Method:    getIncludedRanges
  * Signature: ()Ljava/util/List;
  */

--- a/lib/ch_usi_si_seart_treesitter_Parser_Builder.cc
+++ b/lib/ch_usi_si_seart_treesitter_Parser_Builder.cc
@@ -19,6 +19,11 @@ JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Parser_00024Builder_bu
   } else if (timeout > 0) {
     ts_parser_set_timeout_micros(parser, (uint64_t)timeout);
   }
+  TSLogger logger = {
+    .payload = NULL,
+    .log = __log_in_java
+  };
+  ts_parser_set_logger(parser, logger);
   TSRange ranges[length];
   for (int i = 0; i < length; i++) {
     jobject rangeObject = env->GetObjectArrayElement(rangeObjectArray, i);

--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,13 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-bom</artifactId>
+        <version>2.0.12</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -132,6 +139,17 @@
       <artifactId>annotations</artifactId>
       <version>24.1.0</version>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/src/main/java/ch/usi/si/seart/treesitter/Parser.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Parser.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.FieldDefaults;
 import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
@@ -299,6 +300,29 @@ public class Parser extends External {
     }
 
     private static native void setLanguage(Parser parser, Language language) throws IncompatibleLanguageException;
+
+    /**
+     * Get the {@link Logger} instance used by the parser
+     * for writing debugging information during parsing.
+     *
+     * @return the logger used by the parser
+     * @since 1.12.0
+     */
+    public native Logger getLogger();
+
+    /**
+     * Set the {@link Logger} that a parser should use for
+     * writing debugging information during parsing.
+     * To disable logging, pass {@code null} as an argument.
+     * <p>
+     * By default, the parser will use the {@code DEBUG} level
+     * with a dedicated {@link org.slf4j.Marker Marker} for
+     * either the {@code PARSE} or {@code LEX} events.
+     *
+     * @param logger the logger used by the parser
+     * @since 1.12.0
+     */
+    public native void setLogger(Logger logger);
 
     /**
      * Get an ordered, immutable {@link Range} sequence that corresponds

--- a/src/test/java/ch/usi/si/seart/treesitter/ParserTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/ParserTest.java
@@ -14,6 +14,10 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.helpers.NOPLogger;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -83,6 +87,30 @@ class ParserTest extends BaseTest {
         Point end = range.getEndPoint();
         Assertions.assertEquals(_0_0_, start);
         Assertions.assertEquals(_1_0_, end);
+    }
+
+    private static final class LoggerArgumentsProvider implements ArgumentsProvider {
+
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+            Logger simple = LoggerFactory.getLogger(Parser.class);
+            Logger noop = NOPLogger.NOP_LOGGER;
+            return Stream.of(
+                    Arguments.of(noop),
+                    Arguments.of(simple)
+            );
+        }
+    }
+
+    @ParameterizedTest(name = "[{index}] {0}")
+    @NullSource
+    @ArgumentsSource(LoggerArgumentsProvider.class)
+    void testSetLogger(Logger logger) {
+        @Cleanup Parser parser = Parser.builder().language(Language.PYTHON).build();
+        Assertions.assertNull(parser.getLogger());
+        parser.setLogger(logger);
+        Assertions.assertEquals(logger, parser.getLogger());
+        @Cleanup Tree ignored = parser.parse(source);
     }
 
     @Test

--- a/src/test/resources/simplelogger.properties
+++ b/src/test/resources/simplelogger.properties
@@ -1,0 +1,5 @@
+org.slf4j.simpleLogger.logFile=System.out
+org.slf4j.simpleLogger.defaultLogLevel=debug
+org.slf4j.simpleLogger.showThreadName=false
+org.slf4j.simpleLogger.showDateTime=true
+org.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd HH:mm:ss.SSS


### PR DESCRIPTION
This PR introduces two new instance methods to `Parser`:
- `Parser#getLogger`
- `Parser#setLogger`

It relies on the SLF4J logging facade to forward the information from `tree-sitter` to a `Logger` instance. While writing logs to the `DEBUG` level, it will also include the appropriate log event type in the form of a `Marker`.