### PR TITLE
Add the `Predicate` class

### DIFF
--- a/lib/ch_usi_si_seart_treesitter.cc
+++ b/lib/ch_usi_si_seart_treesitter.cc
@@ -92,6 +92,14 @@ jfieldID _patternIndexField;
 jfieldID _patternValueField;
 jfieldID _patternEnabledField;
 
+jclass _predicateClass;
+jmethodID _predicateConstructor;
+jfieldID _predicatePatternField;
+jfieldID _predicateStepsField;
+
+jclass _predicateStepClass;
+jmethodID _predicateStepConstructor;
+
 jclass _captureClass;
 jmethodID _captureConstructor;
 jfieldID _captureQueryField;
@@ -302,6 +310,15 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved) {
   _loadField(_patternValueField, _patternClass, "value", "Ljava/lang/String;")
   _loadField(_patternEnabledField, _patternClass, "enabled", "Z")
 
+  _loadClass(_predicateClass, "ch/usi/si/seart/treesitter/Predicate")
+  _loadConstructor(_predicateConstructor, _predicateClass,
+    "(Lch/usi/si/seart/treesitter/Pattern;[Lch/usi/si/seart/treesitter/Predicate$Step;)V")
+  _loadField(_predicatePatternField, _predicateClass, "pattern", "Lch/usi/si/seart/treesitter/Pattern;")
+  _loadField(_predicateStepsField, _predicateClass, "steps", "Ljava/util/List;")
+
+  _loadClass(_predicateStepClass, "ch/usi/si/seart/treesitter/Predicate$Step")
+  _loadConstructor(_predicateStepConstructor, _predicateStepClass, "(ILjava/lang/String;)V")
+
   _loadClass(_captureClass, "ch/usi/si/seart/treesitter/Capture")
   _loadConstructor(_captureConstructor, _captureClass, "(ILjava/lang/String;)V")
   _loadField(_captureQueryField, _captureClass, "query", "Lch/usi/si/seart/treesitter/Query;")
@@ -421,6 +438,8 @@ void JNI_OnUnload(JavaVM* vm, void* reserved) {
   _unload(_dotGraphPrinterClass)
   _unload(_queryClass)
   _unload(_patternClass)
+  _unload(_predicateClass)
+  _unload(_predicateStepClass)
   _unload(_captureClass)
   _unload(_queryCursorClass)
   _unload(_symbolClass)

--- a/lib/ch_usi_si_seart_treesitter.cc
+++ b/lib/ch_usi_si_seart_treesitter.cc
@@ -90,6 +90,7 @@ jmethodID _patternConstructor;
 jfieldID _patternQueryField;
 jfieldID _patternIndexField;
 jfieldID _patternValueField;
+jfieldID _patternPredicatesField;
 jfieldID _patternEnabledField;
 
 jclass _predicateClass;
@@ -304,10 +305,12 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved) {
     "(JLch/usi/si/seart/treesitter/Language;[Lch/usi/si/seart/treesitter/Pattern;[Lch/usi/si/seart/treesitter/Capture;[Ljava/lang/String;)V")
 
   _loadClass(_patternClass, "ch/usi/si/seart/treesitter/Pattern")
-  _loadConstructor(_patternConstructor, _patternClass, "(IZZLjava/lang/String;)V")
+  _loadConstructor(_patternConstructor, _patternClass,
+    "(IZZLjava/lang/String;[Lch/usi/si/seart/treesitter/Predicate;)V")
   _loadField(_patternQueryField, _patternClass, "query", "Lch/usi/si/seart/treesitter/Query;")
   _loadField(_patternIndexField, _patternClass, "index", "I")
   _loadField(_patternValueField, _patternClass, "value", "Ljava/lang/String;")
+  _loadField(_patternPredicatesField, _patternClass, "predicates", "Ljava/util/List;")
   _loadField(_patternEnabledField, _patternClass, "enabled", "Z")
 
   _loadClass(_predicateClass, "ch/usi/si/seart/treesitter/Predicate")

--- a/lib/ch_usi_si_seart_treesitter.h
+++ b/lib/ch_usi_si_seart_treesitter.h
@@ -103,6 +103,7 @@ extern jmethodID _patternConstructor;
 extern jfieldID _patternQueryField;
 extern jfieldID _patternIndexField;
 extern jfieldID _patternValueField;
+extern jfieldID _patternPredicatesField;
 extern jfieldID _patternEnabledField;
 
 extern jclass _predicateClass;

--- a/lib/ch_usi_si_seart_treesitter.h
+++ b/lib/ch_usi_si_seart_treesitter.h
@@ -298,6 +298,10 @@ TSRange __unmarshalRange(JNIEnv* env, jobject rangeObject);
 
 TSInputEdit __unmarshalInputEdit(JNIEnv* env, jobject inputEdit);
 
+jobject __marshalPredicateStep(JNIEnv* env, const TSQuery* query, TSQueryPredicateStep step);
+
+jobjectArray __marshalPredicates(JNIEnv* env, const TSQuery* query, const TSQueryPredicateStep* steps, uint32_t* stepsLength, uint32_t* predicatesLength);
+
 const TSLanguage* __unmarshalLanguage(JNIEnv* env, jobject languageObject);
 
 void __log_in_java(void* payload, TSLogType log_type, const char* buffer);

--- a/lib/ch_usi_si_seart_treesitter.h
+++ b/lib/ch_usi_si_seart_treesitter.h
@@ -105,6 +105,14 @@ extern jfieldID _patternIndexField;
 extern jfieldID _patternValueField;
 extern jfieldID _patternEnabledField;
 
+extern jclass _predicateClass;
+extern jmethodID _predicateConstructor;
+extern jfieldID _predicatePatternField;
+extern jfieldID _predicateStepsField;
+
+extern jclass _predicateStepClass;
+extern jmethodID _predicateStepConstructor;
+
 extern jclass _captureClass;
 extern jmethodID _captureConstructor;
 extern jfieldID _captureQueryField;

--- a/lib/ch_usi_si_seart_treesitter_Query_Builder.cc
+++ b/lib/ch_usi_si_seart_treesitter_Query_Builder.cc
@@ -32,14 +32,23 @@ JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Query_00024Builder_bui
           substring[patternLength] = '\0';
           bool rooted = ts_query_is_pattern_rooted(query, i);
           bool nonLocal = ts_query_is_pattern_non_local(query, i);
+          uint32_t stepsLength = 0;
+          uint32_t predicatesLength = 0;
+          const TSQueryPredicateStep* steps = ts_query_predicates_for_pattern(query, i, &stepsLength);
+          jobjectArray predicatesArray = __marshalPredicates(env, query, steps, &stepsLength, &predicatesLength);
           jobject patternObject = _newObject(
             _patternClass,
             _patternConstructor,
             (jint)i,
             (rooted) ? JNI_TRUE : JNI_FALSE,
             (nonLocal) ? JNI_TRUE : JNI_FALSE,
-            env->NewStringUTF(substring)
+            env->NewStringUTF(substring),
+            predicatesArray
           );
+          for (uint32_t j = 0; j < predicatesLength; j++) {
+            jobject predicateObject = env->GetObjectArrayElement(predicatesArray, j);
+            env->SetObjectField(predicateObject, _predicatePatternField, patternObject);
+          }
           env->SetObjectArrayElement(patterns, i, patternObject);
         }
 

--- a/src/main/java/ch/usi/si/seart/treesitter/Pattern.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Pattern.java
@@ -8,6 +8,7 @@ import lombok.experimental.FieldDefaults;
 import lombok.experimental.NonFinal;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -35,12 +36,14 @@ public class Pattern {
 
     String value;
 
+    List<Predicate> predicates;
+
     @NonFinal
     boolean enabled = true;
 
     @SuppressWarnings("unused")
-    Pattern(int index, boolean rooted, boolean nonLocal, @NotNull String value) {
-        this(null, index, rooted, nonLocal, value);
+    Pattern(int index, boolean rooted, boolean nonLocal, @NotNull String value, @NotNull Predicate[] predicates) {
+        this(null, index, rooted, nonLocal, value, List.of(predicates));
     }
 
     /**

--- a/src/main/java/ch/usi/si/seart/treesitter/Predicate.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Predicate.java
@@ -1,0 +1,113 @@
+package ch.usi.si.seart.treesitter;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.experimental.FieldDefaults;
+
+import java.util.List;
+
+/**
+ * A specialised symbolic expression (s-expression) that can
+ * appear anywhere within a {@link Pattern}, instances of this
+ * class represent predicates within a pattern. They consist of
+ * arbitrary metadata and conditions which dictate the matching
+ * behavior of a {@link Query}.
+ * <p>
+ * Note that the actual matching behavior is currently not
+ * implemented in this binding. In spite of this, one can
+ * still use this class to apply matching logic manually.
+ *
+ * @since 1.12.0
+ * @author Ozren Dabić
+ * @see Pattern
+ * @see Query
+ */
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+public class Predicate {
+
+    Pattern pattern;
+    List<Step> steps;
+
+    @SuppressWarnings("unused")
+    Predicate(Pattern pattern, Step[] steps) {
+        this(pattern, List.of(steps));
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < steps.size() - 1; i++) {
+            Step step = steps.get(i);
+            String value = step.getValue();
+            if (i == 0) {
+                builder.append(value);
+                continue;
+            }
+            builder.append(" ");
+            switch (step.getType()) {
+                case CAPTURE:
+                    builder.append("@").append(value);
+                    break;
+                case STRING:
+                    builder.append('"').append(value).append('"');
+                    break;
+                default:
+            }
+        }
+
+        return "(#" + builder + ")";
+    }
+
+    /**
+     * Represents a single step in a {@link Predicate}.
+     * Each step is characterized by a {@link Type Type},
+     * and an optional value.
+     */
+    @Getter
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+    public static class Step {
+
+        Type type;
+        String value;
+
+        public Step(int type, String value) {
+            this(Type.get(type), value);
+        }
+
+        /**
+         * Represents the type of {@link Step Step}.
+         *
+         * @since 1.12.0
+         * @author Ozren Dabić
+         */
+        public enum Type {
+
+            /**
+             * Steps with this type are <em>sentinels</em> that
+             * represent the end of an individual predicate.
+             * Only one such step is allowed per predicate.
+             */
+            DONE,
+
+            /**
+             * Steps with this type represent names of captures.
+             */
+            CAPTURE,
+
+            /**
+             * Steps with this type represent literal strings.
+             */
+            STRING;
+
+            private static final Type[] VALUES = values();
+
+            private static Type get(int ordinal) {
+                return VALUES[ordinal];
+            }
+        }
+    }
+}

--- a/src/main/java/ch/usi/si/seart/treesitter/Predicate.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Predicate.java
@@ -65,6 +65,9 @@ public class Predicate {
      * Represents a single step in a {@link Predicate}.
      * Each step is characterized by a {@link Type Type},
      * and an optional value.
+     *
+     * @since 1.12.0
+     * @author Ozren Dabić
      */
     @Getter
     @AllArgsConstructor(access = AccessLevel.PRIVATE)

--- a/src/test/java/ch/usi/si/seart/treesitter/PredicateTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/PredicateTest.java
@@ -1,0 +1,44 @@
+package ch.usi.si.seart.treesitter;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+class PredicateTest extends BaseTest {
+
+    private static final String expected = "(#any-of? @variable \"document\" \"window\" \"console\")";
+
+    private static final Query query = Query.builder()
+            .language(Language.JAVASCRIPT)
+            .pattern("((identifier) @variable "+expected+")")
+            .build();
+
+    private static final Pattern pattern = query.getPatterns().stream()
+            .findFirst()
+            .orElseThrow();
+
+    @AfterAll
+    static void afterAll() {
+        query.close();
+    }
+
+    @Test
+    void test() {
+        Predicate predicate = pattern.getPredicates().stream()
+                .findFirst()
+                .orElseGet(Assertions::fail);
+        List<Predicate.Step> steps = predicate.getSteps();
+        Assertions.assertFalse(steps.isEmpty());
+        Assertions.assertEquals(6, steps.size());
+        Assertions.assertEquals(
+                Predicate.Step.Type.STRING,
+                steps.stream()
+                        .map(Predicate.Step::getType)
+                        .findFirst()
+                        .orElse(null)
+        );
+        Assertions.assertEquals(expected, predicate.toString());
+    }
+}


### PR DESCRIPTION
This PR introduces a class dedicated to storing `Query` predicate conditions and data for a `Pattern`. Although this is currently not used in `Node` matching, the fact that we make this abstraction available to the users allows them to do so manually. I hope to implement the automatic matching similar to the Rust binding in one of the subsequent versions.