### PR TITLE
`Language` enum values now provide all field names

### DIFF
--- a/lib/ch_usi_si_seart_treesitter_Language.cc
+++ b/lib/ch_usi_si_seart_treesitter_Language.cc
@@ -541,6 +541,14 @@ JNIEXPORT jint JNICALL Java_ch_usi_si_seart_treesitter_Language_fields(
   return (jint)ts_language_field_count(language);
 }
 
+JNIEXPORT jstring JNICALL Java_ch_usi_si_seart_treesitter_Language_field(
+  JNIEnv* env, jclass self, jlong languageId, jint fieldId) {
+  TSLanguage* language = (TSLanguage*)languageId;
+  TSFieldId field = (TSFieldId)fieldId;
+  const char* name = ts_language_field_name_for_id(language, field);
+  return env->NewStringUTF(name);
+}
+
 JNIEXPORT jint JNICALL Java_ch_usi_si_seart_treesitter_Language_states(
   JNIEnv* env, jclass self, jlong id) {
   TSLanguage* language = (TSLanguage*)id;

--- a/lib/ch_usi_si_seart_treesitter_Language.h
+++ b/lib/ch_usi_si_seart_treesitter_Language.h
@@ -491,6 +491,14 @@ JNIEXPORT jint JNICALL Java_ch_usi_si_seart_treesitter_Language_fields
 
 /*
  * Class:     ch_usi_si_seart_treesitter_Language
+ * Method:    field
+ * Signature: (JI)Ljava/lang/String;
+ */
+JNIEXPORT jstring JNICALL Java_ch_usi_si_seart_treesitter_Language_field
+  (JNIEnv *, jclass, jlong, jint);
+
+/*
+ * Class:     ch_usi_si_seart_treesitter_Language
  * Method:    states
  * Signature: (J)I
  */

--- a/src/main/java/ch/usi/si/seart/treesitter/Language.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Language.java
@@ -545,9 +545,9 @@ public enum Language {
 
     long id;
     int version;
-    int totalFields;
     int totalStates;
     List<Symbol> symbols;
+    List<String> fields;
     List<String> extensions;
 
     private static final long INVALID = 0L;
@@ -581,10 +581,12 @@ public enum Language {
     Language(long id, int version, int totalStates, int totalSymbols, int totalFields, List<String> extensions) {
         this.id = id;
         this.version = version;
-        this.totalFields = totalFields;
         this.totalStates = totalStates;
         this.symbols = IntStream.range(0, totalSymbols)
                 .mapToObj(symbolId -> symbol(id, symbolId))
+                .collect(Collectors.toUnmodifiableList());
+        this.fields = IntStream.range(0, totalFields)
+                .mapToObj(fieldId -> field(id, fieldId))
                 .collect(Collectors.toUnmodifiableList());
         this.extensions = extensions;
     }
@@ -633,6 +635,11 @@ public enum Language {
     @SuppressWarnings("unused")
     public int getTotalSymbols() {
         return symbols.size();
+    }
+    @Generated
+    @SuppressWarnings("unused")
+    public int getTotalFields() {
+        return fields.size();
     }
 
     @Override

--- a/src/main/java/ch/usi/si/seart/treesitter/Language.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Language.java
@@ -540,6 +540,7 @@ public enum Language {
     private static native int symbols(long id);
     private static native Symbol symbol(long languageId, int symbolId);
     private static native int fields(long id);
+    private static native String field(long languageId, int fieldId);
     private static native int states(long id);
 
     long id;

--- a/src/main/java/ch/usi/si/seart/treesitter/Language.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Language.java
@@ -585,7 +585,7 @@ public enum Language {
         this.symbols = IntStream.range(0, totalSymbols)
                 .mapToObj(symbolId -> symbol(id, symbolId))
                 .collect(Collectors.toUnmodifiableList());
-        this.fields = IntStream.range(0, totalFields)
+        this.fields = IntStream.range(1, totalFields + 1)
                 .mapToObj(fieldId -> field(id, fieldId))
                 .collect(Collectors.toUnmodifiableList());
         this.extensions = extensions;

--- a/src/main/java/ch/usi/si/seart/treesitter/Language.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Language.java
@@ -631,13 +631,20 @@ public enum Language {
 
     private static native int nextState(long id, int state, int symbol);
 
+    /**
+     * @deprecated Just calculate the {@link List#size() size} of the list returned by {@link #getSymbols()}.
+     */
     @Generated
-    @SuppressWarnings("unused")
+    @Deprecated(forRemoval = true, since = "1.12.0")
     public int getTotalSymbols() {
         return symbols.size();
     }
+
+    /**
+     * @deprecated Just calculate the {@link List#size() size} of the list returned by {@link #getFields()}.
+     */
     @Generated
-    @SuppressWarnings("unused")
+    @Deprecated(forRemoval = true, since = "1.12.0")
     public int getTotalFields() {
         return fields.size();
     }

--- a/src/main/java/ch/usi/si/seart/treesitter/Language.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Language.java
@@ -575,10 +575,10 @@ public enum Language {
             ));
 
     Language(long id, String... extensions) {
-        this(id, version(id), fields(id), states(id), symbols(id), List.of(extensions));
+        this(id, version(id), states(id), symbols(id), fields(id), List.of(extensions));
     }
 
-    Language(long id, int version, int totalFields, int totalStates, int totalSymbols, List<String> extensions) {
+    Language(long id, int version, int totalStates, int totalSymbols, int totalFields, List<String> extensions) {
         this.id = id;
         this.version = version;
         this.totalFields = totalFields;

--- a/src/main/java/ch/usi/si/seart/treesitter/Language.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Language.java
@@ -547,7 +547,7 @@ public enum Language {
     int version;
     int totalFields;
     int totalStates;
-    Collection<Symbol> symbols;
+    List<Symbol> symbols;
     List<String> extensions;
 
     private static final long INVALID = 0L;

--- a/src/test/java/ch/usi/si/seart/treesitter/BaseTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/BaseTest.java
@@ -26,10 +26,10 @@ public abstract class BaseTest {
 
         Mockito.when(invalid.getId()).thenReturn(0L);
         Mockito.when(invalid.getVersion()).thenReturn(0);
-        Mockito.when(invalid.getTotalFields()).thenReturn(0);
         Mockito.when(invalid.getTotalStates()).thenReturn(0);
-        Mockito.when(invalid.getTotalSymbols()).thenReturn(0);
         Mockito.when(invalid.getSymbols()).thenReturn(List.of());
+        Mockito.when(invalid.getFields()).thenReturn(List.of());
+        Mockito.when(invalid.getExtensions()).thenReturn(List.of());
 
         Mockito.when(invalid.nextState(Mockito.any())).thenCallRealMethod();
     }


### PR DESCRIPTION
As opposed to just providing the `totalFields` count, we instead now provide a complete collection of field names in the aptly named `fields` instance variable. This PR also introduces the following changes:

- Type change from `Collection` to `List` for all `Language` container member;
- Deprecation (with eventual removal) of:
	- `Language#getTotalSymbols`
	- `Language#getTotalFields`