### PR TITLE
Add precise start and end offset byte values for `Pattern`

### DIFF
--- a/lib/ch_usi_si_seart_treesitter.cc
+++ b/lib/ch_usi_si_seart_treesitter.cc
@@ -89,6 +89,7 @@ jclass _patternClass;
 jmethodID _patternConstructor;
 jfieldID _patternQueryField;
 jfieldID _patternIndexField;
+jfieldID _patternStartOffsetField;
 jfieldID _patternValueField;
 jfieldID _patternPredicatesField;
 jfieldID _patternEnabledField;
@@ -306,9 +307,10 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved) {
 
   _loadClass(_patternClass, "ch/usi/si/seart/treesitter/Pattern")
   _loadConstructor(_patternConstructor, _patternClass,
-    "(IZZLjava/lang/String;[Lch/usi/si/seart/treesitter/Predicate;)V")
+    "(IIZZLjava/lang/String;[Lch/usi/si/seart/treesitter/Predicate;)V")
   _loadField(_patternQueryField, _patternClass, "query", "Lch/usi/si/seart/treesitter/Query;")
   _loadField(_patternIndexField, _patternClass, "index", "I")
+  _loadField(_patternStartOffsetField, _patternClass, "startOffset", "I")
   _loadField(_patternValueField, _patternClass, "value", "Ljava/lang/String;")
   _loadField(_patternPredicatesField, _patternClass, "predicates", "Ljava/util/List;")
   _loadField(_patternEnabledField, _patternClass, "enabled", "Z")

--- a/lib/ch_usi_si_seart_treesitter.h
+++ b/lib/ch_usi_si_seart_treesitter.h
@@ -102,6 +102,7 @@ extern jclass _patternClass;
 extern jmethodID _patternConstructor;
 extern jfieldID _patternQueryField;
 extern jfieldID _patternIndexField;
+extern jfieldID _patternStartOffsetField;
 extern jfieldID _patternValueField;
 extern jfieldID _patternPredicatesField;
 extern jfieldID _patternEnabledField;

--- a/lib/ch_usi_si_seart_treesitter_Query_Builder.cc
+++ b/lib/ch_usi_si_seart_treesitter_Query_Builder.cc
@@ -40,6 +40,7 @@ JNIEXPORT jobject JNICALL Java_ch_usi_si_seart_treesitter_Query_00024Builder_bui
             _patternClass,
             _patternConstructor,
             (jint)i,
+            (jint)byteLower,
             (rooted) ? JNI_TRUE : JNI_FALSE,
             (nonLocal) ? JNI_TRUE : JNI_FALSE,
             env->NewStringUTF(substring),

--- a/src/main/java/ch/usi/si/seart/treesitter/Pattern.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Pattern.java
@@ -52,7 +52,7 @@ public class Pattern {
             @NotNull String value,
             @NotNull Predicate[] predicates
     ) {
-        this(null, index, startOffset, rooted, nonLocal, value, List.of(predicates));
+        this(null, index, startOffset, rooted, nonLocal, value.stripTrailing(), List.of(predicates));
     }
 
     /**
@@ -65,6 +65,11 @@ public class Pattern {
      * </strong>
      */
     public native void disable();
+
+    @Generated
+    public int getEndOffset() {
+        return startOffset + value.length();
+    }
 
     @Override
     @Generated

--- a/src/main/java/ch/usi/si/seart/treesitter/Pattern.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Pattern.java
@@ -31,6 +31,8 @@ public class Pattern {
 
     int index;
 
+    int startOffset;
+
     boolean rooted;
     boolean nonLocal;
 
@@ -42,8 +44,15 @@ public class Pattern {
     boolean enabled = true;
 
     @SuppressWarnings("unused")
-    Pattern(int index, boolean rooted, boolean nonLocal, @NotNull String value, @NotNull Predicate[] predicates) {
-        this(null, index, rooted, nonLocal, value, List.of(predicates));
+    Pattern(
+            int index,
+            int startOffset,
+            boolean rooted,
+            boolean nonLocal,
+            @NotNull String value,
+            @NotNull Predicate[] predicates
+    ) {
+        this(null, index, startOffset, rooted, nonLocal, value, List.of(predicates));
     }
 
     /**

--- a/src/main/java/ch/usi/si/seart/treesitter/Query.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Query.java
@@ -6,6 +6,7 @@ import lombok.Generated;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.FieldDefaults;
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -186,8 +187,16 @@ public class Query extends External {
          */
         public Query build() {
             Objects.requireNonNull(language, "Language must not be null!");
-            String pattern = String.join(" ", patterns).trim();
-            return build(language, pattern);
+            String joined = String.join(" ", patterns);
+            return build(language, normalize(joined));
+        }
+
+        private static String normalize(String pattern) {
+            return StringUtils.normalizeSpace(pattern)
+                    .replace(" )", ")")
+                    .replace("( ", "(")
+                    .replace(" ]", "]")
+                    .replace("[ ", "[");
         }
 
         private static native Query build(Language language, String pattern) throws QueryException;

--- a/src/test/java/ch/usi/si/seart/treesitter/PatternTest.java
+++ b/src/test/java/ch/usi/si/seart/treesitter/PatternTest.java
@@ -2,18 +2,62 @@ package ch.usi.si.seart.treesitter;
 
 import lombok.Cleanup;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
-class PatternTest extends AbstractQueryTest {
+import java.util.List;
 
-    @Override
-    protected void assertions(Node node, Query query) {
+class PatternTest extends BaseTest {
+
+    @ParameterizedTest(name = "[{index}] {0}")
+    @ValueSource(strings = {
+        "(line_comment)(block_comment)",
+        "(line_comment) (block_comment)",
+        "(line_comment ) (block_comment )",
+        "(line_comment ) ( block_comment)",
+        "( line_comment) (block_comment )",
+        "( line_comment ) ( block_comment )",
+        "(line_comment)     (block_comment)",
+        "(line_comment   )(   block_comment)",
+        "   (line_comment) (block_comment)   ",
+    })
+    void test(String string) {
+        List<String> parts = List.of("(line_comment)", "(block_comment)");
+        @Cleanup Query query = Query.builder()
+                .language(Language.JAVA)
+                .pattern(string)
+                .build();
+        Assertions.assertEquals(String.join(" ", parts), query.getPattern());
+        List<Pattern> patterns = query.getPatterns();
+        Assertions.assertFalse(patterns.isEmpty());
+        Assertions.assertEquals(2, patterns.size());
+        for (int i = 0; i < patterns.size(); i++) {
+            Pattern pattern = patterns.get(i);
+            Assertions.assertTrue(pattern.getStartOffset() >= 0);
+            Assertions.assertTrue(pattern.getStartOffset() < pattern.getEndOffset());
+            String actual = pattern.getValue();
+            String expected = parts.get(i);
+            Assertions.assertEquals(expected, actual);
+        }
+    }
+
+    @Test
+    void testDisable() {
+        @Cleanup Parser parser = Parser.getFor(Language.PYTHON);
+        @Cleanup Tree tree = parser.parse("pass");
+        @Cleanup Query query = Query.builder()
+                .language(Language.PYTHON)
+                .pattern("(module) @capture")
+                .build();
+        Node root = tree.getRootNode();
         Pattern pattern = query.getPatterns().stream()
                 .findFirst()
                 .orElseGet(Assertions::fail);
         Assertions.assertTrue(pattern.isEnabled());
         pattern.disable();
         Assertions.assertFalse(pattern.isEnabled());
-        @Cleanup QueryCursor cursor = node.walk(query);
+        @Cleanup QueryCursor cursor = root.walk(query);
         for (QueryMatch ignored: cursor) Assertions.fail();
         Assertions.assertFalse(pattern.isEnabled());
         pattern.disable();


### PR DESCRIPTION
This PR introduces the ability to determine the exact location of a `Pattern` within a `Query`. For this to work properly, all user-submitted queries have to be normalized to a minimal, but human-readable format.