### PR TITLE
Synchronize remote URLs for relocated grammars

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -69,7 +69,7 @@
 	url = https://github.com/tree-sitter/tree-sitter-haskell.git
 [submodule "tree-sitter-hcl"]
 	path = tree-sitter-hcl
-	url = https://github.com/MichaHoffmann/tree-sitter-hcl.git
+	url = https://github.com/tree-sitter-grammars/tree-sitter-hcl.git
 [submodule "tree-sitter-html"]
 	path = tree-sitter-html
 	url = https://github.com/tree-sitter/tree-sitter-html.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -21,7 +21,7 @@
 	url = https://github.com/uyha/tree-sitter-cmake.git
 [submodule "tree-sitter-common-lisp"]
 	path = tree-sitter-common-lisp
-	url = https://github.com/theHamsta/tree-sitter-commonlisp.git
+	url = https://github.com/tree-sitter-grammars/tree-sitter-commonlisp.git
 [submodule "tree-sitter-cpp"]
 	path = tree-sitter-cpp
 	url = https://github.com/tree-sitter/tree-sitter-cpp.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -93,7 +93,7 @@
 	url = https://github.com/latex-lsp/tree-sitter-latex.git
 [submodule "tree-sitter-lua"]
 	path = tree-sitter-lua
-	url = https://github.com/Azganoth/tree-sitter-lua.git
+	url = https://github.com/tree-sitter-grammars/tree-sitter-lua.git
 [submodule "tree-sitter-markdown"]
 	path = tree-sitter-markdown
 	url = https://github.com/MDeiml/tree-sitter-markdown.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -96,7 +96,7 @@
 	url = https://github.com/tree-sitter-grammars/tree-sitter-lua.git
 [submodule "tree-sitter-markdown"]
 	path = tree-sitter-markdown
-	url = https://github.com/MDeiml/tree-sitter-markdown.git
+	url = https://github.com/tree-sitter-grammars/tree-sitter-markdown.git
 [submodule "tree-sitter-nix"]
 	path = tree-sitter-nix
 	url = https://github.com/nix-community/tree-sitter-nix.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -36,7 +36,7 @@
 	url = https://github.com/rydesun/tree-sitter-dot.git
 [submodule "tree-sitter-dtd"]
 	path = tree-sitter-dtd
-	url = https://github.com/ObserverOfTime/tree-sitter-xml.git
+	url = https://github.com/tree-sitter-grammars/tree-sitter-xml.git
 [submodule "tree-sitter-elixir"]
 	path = tree-sitter-elixir
 	url = https://github.com/elixir-lang/tree-sitter-elixir.git
@@ -162,7 +162,7 @@
 	url = https://github.com/tree-sitter/tree-sitter-verilog.git
 [submodule "tree-sitter-xml"]
 	path = tree-sitter-xml
-	url = https://github.com/ObserverOfTime/tree-sitter-xml.git
+	url = https://github.com/tree-sitter-grammars/tree-sitter-xml.git
 [submodule "tree-sitter-yaml"]
 	path = tree-sitter-yaml
 	url = https://github.com/ikatyang/tree-sitter-yaml.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -144,7 +144,7 @@
 	url = https://github.com/alex-pinkus/tree-sitter-swift.git
 [submodule "tree-sitter-thrift"]
 	path = tree-sitter-thrift
-	url = https://github.com/duskmoon314/tree-sitter-thrift.git
+	url = https://github.com/tree-sitter-grammars/tree-sitter-thrift.git
 [submodule "tree-sitter-toml"]
 	path = tree-sitter-toml
 	url = https://github.com/ikatyang/tree-sitter-toml.git

--- a/src/main/java/ch/usi/si/seart/treesitter/Language.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Language.java
@@ -375,7 +375,7 @@ public enum Language {
     /**
      * Thrift interface description language.
      *
-     * @see <a href="https://github.com/duskmoon314/tree-sitter-thrift">tree-sitter-thrift</a>
+     * @see <a href="https://github.com/tree-sitter-grammars/tree-sitter-thrift">tree-sitter-thrift</a>
      */
     THRIFT(thrift(), "thrift"),
 

--- a/src/main/java/ch/usi/si/seart/treesitter/Language.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Language.java
@@ -193,7 +193,7 @@ public enum Language {
     /**
      * HCL: HashiCorp Configuration Language.
      *
-     * @see <a href="https://github.com/MichaHoffmann/tree-sitter-hcl">tree-sitter-hcl</a>
+     * @see <a href="https://github.com/tree-sitter-grammars/tree-sitter-hcl">tree-sitter-hcl</a>
      */
     HCL(hcl(), "hcl", "tf", "tfvars"),
 

--- a/src/main/java/ch/usi/si/seart/treesitter/Language.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Language.java
@@ -81,7 +81,7 @@ public enum Language {
     /**
      * Common Lisp programming language.
      *
-     * @see <a href="https://github.com/theHamsta/tree-sitter-commonlisp">tree-sitter-commonlisp</a>
+     * @see <a href="https://github.com/tree-sitter-grammars/tree-sitter-commonlisp">tree-sitter-commonlisp</a>
      */
     COMMON_LISP(commonLisp(), "lisp"),
 

--- a/src/main/java/ch/usi/si/seart/treesitter/Language.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Language.java
@@ -263,7 +263,7 @@ public enum Language {
     /**
      * Markdown markup language for creating formatted text.
      *
-     * @see <a href="https://github.com/MDeiml/tree-sitter-markdown">tree-sitter-markdown</a>
+     * @see <a href="https://github.com/tree-sitter-grammars/tree-sitter-markdown">tree-sitter-markdown</a>
      */
     MARKDOWN(markdown(), "md"),
 

--- a/src/main/java/ch/usi/si/seart/treesitter/Language.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Language.java
@@ -123,7 +123,7 @@ public enum Language {
     /**
      * DTD: Document Type Definition.
      *
-     * @see <a href="https://github.com/ObserverOfTime/tree-sitter-xml">tree-sitter-xml</a>
+     * @see <a href="https://github.com/tree-sitter-grammars/tree-sitter-xml">tree-sitter-xml</a>
      */
     DTD(dtd(), "dtd"),
 
@@ -417,7 +417,7 @@ public enum Language {
     /**
      * XML: Extensible Markup Language.
      *
-     * @see <a href="https://github.com/ObserverOfTime/tree-sitter-xml">tree-sitter-xml</a>
+     * @see <a href="https://github.com/tree-sitter-grammars/tree-sitter-xml">tree-sitter-xml</a>
      */
     XML(xml(), "svg", "xml", "xsd", "xslt"),
 

--- a/src/main/java/ch/usi/si/seart/treesitter/Language.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Language.java
@@ -256,7 +256,7 @@ public enum Language {
     /**
      * Lua programming language.
      *
-     * @see <a href="https://github.com/Azganoth/tree-sitter-lua">tree-sitter-lua</a>
+     * @see <a href="https://github.com/tree-sitter-grammars/tree-sitter-lua">tree-sitter-lua</a>
      */
     LUA(lua(), "lua"),
 


### PR DESCRIPTION
The repositories of all the targeted grammars have been relocated from their respective owners over to the @tree-sitter-grammars organization. The list includes:

- Common Lisp
- HCL
- Lua
- Markdown
- Thrift
- XML & DTD

Even though the old URLs still point to the new repositories, we want to keep all the data in sync to inform our clients.