### PR TITLE
Add language binding: `tree-sitter-cobol`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,6 +22,9 @@
 [submodule "tree-sitter-cmake"]
 	path = tree-sitter-cmake
 	url = https://github.com/uyha/tree-sitter-cmake.git
+[submodule "tree-sitter-cobol"]
+	path = tree-sitter-cobol
+	url = https://github.com/yutaro-sakamoto/tree-sitter-cobol.git
 [submodule "tree-sitter-common-lisp"]
 	path = tree-sitter-common-lisp
 	url = https://github.com/tree-sitter-grammars/tree-sitter-commonlisp.git

--- a/lib/ch_usi_si_seart_treesitter.h
+++ b/lib/ch_usi_si_seart_treesitter.h
@@ -341,6 +341,9 @@ TSLanguage* tree_sitter_clojure();
 #ifdef TS_LANGUAGE_CMAKE
 TSLanguage* tree_sitter_cmake();
 #endif
+#ifdef TS_LANGUAGE_COBOL
+TSLanguage* tree_sitter_COBOL();
+#endif
 #ifdef TS_LANGUAGE_COMMON_LISP
 TSLanguage* tree_sitter_commonlisp();
 #endif

--- a/lib/ch_usi_si_seart_treesitter_Language.cc
+++ b/lib/ch_usi_si_seart_treesitter_Language.cc
@@ -67,6 +67,15 @@ JNIEXPORT jlong JNICALL Java_ch_usi_si_seart_treesitter_Language_cmake(
 #endif
 }
 
+JNIEXPORT jlong JNICALL Java_ch_usi_si_seart_treesitter_Language_cobol(
+  JNIEnv* env, jclass self) {
+#ifdef TS_LANGUAGE_COBOL
+  return (jlong)tree_sitter_COBOL();
+#else
+  return (jlong)ch_usi_si_seart_treesitter_Language_INVALID;
+#endif
+}
+
 JNIEXPORT jlong JNICALL Java_ch_usi_si_seart_treesitter_Language_commonLisp(
   JNIEnv* env, jclass self) {
 #ifdef TS_LANGUAGE_COMMON_LISP

--- a/lib/ch_usi_si_seart_treesitter_Language.h
+++ b/lib/ch_usi_si_seart_treesitter_Language.h
@@ -67,6 +67,14 @@ JNIEXPORT jlong JNICALL Java_ch_usi_si_seart_treesitter_Language_cmake
 
 /*
  * Class:     ch_usi_si_seart_treesitter_Language
+ * Method:    cobol
+ * Signature: ()J
+ */
+JNIEXPORT jlong JNICALL Java_ch_usi_si_seart_treesitter_Language_cobol
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     ch_usi_si_seart_treesitter_Language
  * Method:    cSharp
  * Signature: ()J
  */

--- a/src/main/java/ch/usi/si/seart/treesitter/Language.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Language.java
@@ -86,6 +86,13 @@ public enum Language {
     CMAKE(cmake(), "cmake"),
 
     /**
+     * COBOL: Common Business-Oriented Language.
+     *
+     * @see <a href="https://github.com/yutaro-sakamoto/tree-sitter-cobol">tree-sitter-cobol</a>
+     */
+    COBOL(cobol(), "cbl", "cob"),
+
+    /**
      * Common Lisp programming language.
      *
      * @see <a href="https://github.com/tree-sitter-grammars/tree-sitter-commonlisp">tree-sitter-commonlisp</a>
@@ -449,6 +456,7 @@ public enum Language {
     private static native long clojure();
     private static native long commonLisp();
     private static native long cmake();
+    private static native long cobol();
     private static native long cSharp();
     private static native long cpp();
     private static native long css();
@@ -664,6 +672,7 @@ public enum Language {
              * Uppercase
              */
             case C:
+            case COBOL:
             case CSS:
             case DOT:
             case DTD:


### PR DESCRIPTION
Note: It would appear that the grammar does not support COBOL Copybooks.
See: https://github.com/yutaro-sakamoto/tree-sitter-cobol/pull/11