### PR TITLE
Add language binding: `tree-sitter-sql`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -160,6 +160,9 @@
 [submodule "tree-sitter-scss"]
 	path = tree-sitter-scss
 	url = https://github.com/serenadeai/tree-sitter-scss.git
+[submodule "tree-sitter-sql"]
+	path = tree-sitter-sql
+	url = https://github.com/DerekStride/tree-sitter-sql.git
 [submodule "tree-sitter-svelte"]
 	path = tree-sitter-svelte
 	url = https://github.com/Himujjal/tree-sitter-svelte.git

--- a/lib/ch_usi_si_seart_treesitter.h
+++ b/lib/ch_usi_si_seart_treesitter.h
@@ -479,6 +479,9 @@ TSLanguage* tree_sitter_scheme();
 #ifdef TS_LANGUAGE_SCSS
 TSLanguage* tree_sitter_scss();
 #endif
+#ifdef TS_LANGUAGE_SQL
+TSLanguage* tree_sitter_sql();
+#endif
 #ifdef TS_LANGUAGE_SVELTE
 TSLanguage* tree_sitter_svelte();
 #endif

--- a/lib/ch_usi_si_seart_treesitter_Language.cc
+++ b/lib/ch_usi_si_seart_treesitter_Language.cc
@@ -481,6 +481,15 @@ JNIEXPORT jlong JNICALL Java_ch_usi_si_seart_treesitter_Language_scss(
 #endif
 }
 
+JNIEXPORT jlong JNICALL Java_ch_usi_si_seart_treesitter_Language_sql(
+  JNIEnv* env, jclass self) {
+#ifdef TS_LANGUAGE_SQL
+  return (jlong)tree_sitter_sql();
+#else
+  return (jlong)ch_usi_si_seart_treesitter_Language_INVALID;
+#endif
+}
+
 JNIEXPORT jlong JNICALL Java_ch_usi_si_seart_treesitter_Language_svelte(
   JNIEnv* env, jclass self) {
 #ifdef TS_LANGUAGE_SVELTE

--- a/lib/ch_usi_si_seart_treesitter_Language.h
+++ b/lib/ch_usi_si_seart_treesitter_Language.h
@@ -435,6 +435,14 @@ JNIEXPORT jlong JNICALL Java_ch_usi_si_seart_treesitter_Language_scss
 
 /*
  * Class:     ch_usi_si_seart_treesitter_Language
+ * Method:    sql
+ * Signature: ()J
+ */
+JNIEXPORT jlong JNICALL Java_ch_usi_si_seart_treesitter_Language_sql
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     ch_usi_si_seart_treesitter_Language
  * Method:    svelte
  * Signature: ()J
  */

--- a/src/main/java/ch/usi/si/seart/treesitter/Language.java
+++ b/src/main/java/ch/usi/si/seart/treesitter/Language.java
@@ -415,6 +415,13 @@ public enum Language {
     SCSS(scss(), "scss"),
 
     /**
+     * SQL: Structured Query Language.
+     *
+     * @see <a href="https://github.com/DerekStride/tree-sitter-sql">tree-sitter-sql</a>
+     */
+    SQL(sql(), "sql"),
+
+    /**
      * Svelte front-end component framework.
      *
      * @see <a href="https://github.com/Himujjal/tree-sitter-svelte">tree-sitter-svelte</a>
@@ -551,6 +558,7 @@ public enum Language {
     private static native long scala();
     private static native long scheme();
     private static native long scss();
+    private static native long sql();
     private static native long svelte();
     private static native long swift();
     private static native long thrift();
@@ -741,6 +749,7 @@ public enum Language {
             case PSV:
             case R:
             case SCSS:
+            case SQL:
             case TOML:
             case TSV:
             case TSX:


### PR DESCRIPTION
Note: Only covers the _generic_ SQL grammar. Vendor-specific features will be supported with flavoured grammar variations.