### PR TITLE
Replace manual submodule updates with `ch.usi.si.seart:git-submodule-maven-plugin`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -430,20 +430,22 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>ch.usi.si.seart</groupId>
+        <artifactId>git-submodule-maven-plugin</artifactId>
+        <version>1.1.0</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>update</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
         <version>3.4.1</version>
         <executions>
-          <execution>
-            <id>git-update-submodules</id>
-            <phase>initialize</phase>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-            <configuration>
-              <executable>update.sh</executable>
-            </configuration>
-          </execution>
           <execution>
             <id>generate-api-version-file</id>
             <phase>generate-sources</phase>

--- a/update.sh
+++ b/update.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-git submodule update --init
-git submodule foreach git submodule update --init


### PR DESCRIPTION
Removes redundant script and simplifies the release process.